### PR TITLE
opendap.ipynb: get ESGF auth from environment var to avoid hardcode in notebook

### DIFF
--- a/docs/source/notebooks/climate_indices.ipynb
+++ b/docs/source/notebooks/climate_indices.ipynb
@@ -18,9 +18,13 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "import os\n",
     "from birdy import WPSClient\n",
+    "\n",
+    "verify_ssl = True if 'DISABLE_VERIFY_SSL' not in os.environ else False\n",
+    "\n",
     "url = 'https://pavics.ouranos.ca/twitcher/ows/proxy/flyingpigeon/wps'\n",
-    "fp = WPSClient(url)"
+    "fp = WPSClient(url, verify=verify_ssl)"
    ]
   },
   {
@@ -90,7 +94,7 @@
    "source": [
     "thredds = 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/flyingpigeon/'\n",
     "resp = fp.icclim_tx(resource=thredds+'cmip3/tas.sresb1.giss_model_e_r.run1.atm.da.nc', grouping='yr')\n",
-    "tx, log = resp.get(asobj=True)\n",
+    "tx, log = resp.get(asobj=True, verify=verify_ssl)\n",
     "tx"
    ]
   },

--- a/docs/source/notebooks/opendap.ipynb
+++ b/docs/source/notebooks/opendap.ipynb
@@ -182,13 +182,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import xarray as xr\n",
     "from pydap.cas.esgf import setup_session\n",
     "# ds_url = \"http://esgfcog.cccma.ec.gc.ca/thredds/dodsC/cmip5.output.CCCma.CanESM2.rcp85.mon.atmos.r4i1p1.pr.20130331.aggregation\"\n",
     "# The CCCMA server fails with an SSLError...\n",
     "# ds_url = \"https://esgf1.dkrz.de/thredds/dodsC/cmip5.output1.MPI-M.MPI-ESM-MR.rcp85.day.atmos.day.r1i1p1.uas.20120503.aggregation\"\n",
     "ds_url = \"https://esgf1.dkrz.de/thredds/dodsC/cmip5.output1.MPI-M.MPI-ESM-MR.rcp85.mon.atmos.Amon.r1i1p1.pr.20120503.aggregation\"\n",
-    "session = setup_session('<your openid>', '<password>', check_url=ds_url)\n",
+    "username = os.environ.get('ESGF_AUTH_USERNAME', '<your openid>')\n",
+    "password = os.environ.get('ESGF_AUTH_PASSWORD', '<password>')\n",
+    "session = setup_session(username, password, check_url=ds_url)\n",
     "store = xr.backends.PydapDataStore.open(ds_url, session=session)\n",
     "ds = xr.open_dataset(store)\n",
     "ds.attrs"

--- a/docs/source/notebooks/subsetting.ipynb
+++ b/docs/source/notebooks/subsetting.ipynb
@@ -33,9 +33,13 @@
    ],
    "source": [
     "%matplotlib inline\n",
+    "import os\n",
     "import xarray as xr\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
+    "\n",
+    "verify_ssl = True if 'DISABLE_VERIFY_SSL' not in os.environ else False\n",
+    "\n",
     "# The dodsC link for the test file\n",
     "dap = 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/'\n",
     "ncfile = 'birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200601-200612.nc'\n",
@@ -75,7 +79,7 @@
    "source": [
     "from birdy import WPSClient\n",
     "url = 'https://pavics.ouranos.ca/twitcher/ows/proxy/flyingpigeon/wps'\n",
-    "fp = WPSClient(url)"
+    "fp = WPSClient(url, verify=verify_ssl)"
    ]
   },
   {
@@ -157,8 +161,8 @@
     }
    ],
    "source": [
-    "resp.get()\n",
-    "tar_out, nc_out, log = resp.get(asobj=True)"
+    "resp.get(verify=verify_ssl)\n",
+    "tar_out, nc_out, log = resp.get(asobj=True, verify=verify_ssl)"
    ]
   },
   {


### PR DESCRIPTION
See build on prod Jenkins http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/feature%252Ftest-more-repos-more-pavics-hosts-and-various-improvements/3/console. Note this build is building this `feature/get_esfg_auth_from_envvar` branch and not `master` so we can now target the branch we want.

It got past the authentication issue but now is failing with `IndexError: too many indices for array`, is that expected?