### PR TITLE
catalog_search.ipynb: update to match new pavics/pavics-datacatalog:0.6.11

### DIFF
--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -20,7 +20,7 @@
      "text": [
       "Help on method pavicsearch in module birdy.client.base:\n",
       "\n",
-      "pavicsearch(facets=None, shards='*', offset=None, limit=None, fields='*', format='application/solr+json', query='*', distrib=None, type='Dataset', constraints=None, esgf=None, list_type='opendap_url') method of birdy.client.base.WPSClient instance\n",
+      "pavicsearch(facets='None', shards='*', offset=0, limit=0, fields='*', format='application/solr+json', query='*', distrib=False, type='Dataset', constraints='None', esgf=False, list_type='opendap_url') method of birdy.client.base.WPSClient instance\n",
       "    Search the PAVICS database and return a catalogue of matches.\n",
       "    \n",
       "    Parameters\n",
@@ -192,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/opendap.ipynb
+++ b/docs/source/notebooks/opendap.ipynb
@@ -51,7 +51,7 @@
     {
      "data": {
       "text/plain": [
-       "odict_keys(['lat', 'lon', 'time', 'sea_surface_temperature', 'sst_dtime', 'proximity_confidence', 'SSES_bias_error', 'SSES_standard_deviation_error', 'rejection_flag', 'confidence_flag', 'sea_surface_temperature4', 'proximity_confidence4', 'SSES_bias_error4', 'SSES_standard_deviation_error4'])"
+       "dict_keys(['lat', 'lon', 'time', 'sea_surface_temperature', 'sst_dtime', 'proximity_confidence', 'SSES_bias_error', 'SSES_standard_deviation_error', 'rejection_flag', 'confidence_flag', 'sea_surface_temperature4', 'proximity_confidence4', 'SSES_bias_error4', 'SSES_standard_deviation_error4'])"
       ]
      },
      "execution_count": 2,
@@ -192,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix Jenkins error:

```
  assert reference_output == test_output failed:

   'Help on meth...h result.\n\n' == 'Help on meth...h result.\n\n'
   Skipping 66 identical leading characters in diff, use -v to show
   Skipping 1283 identical trailing characters in diff, use -v to show
   - ch(facets=None, shards='*', offset=None, limit=None, fields='*', format='application/solr+json', query='*', distrib=None, type='Dataset', constraints=None, esgf=None, list_t
   ?                                    ^^^^        ^^^^                                                                 ^^^                                          ^^^
   + ch(facets='None', shards='*', offset=0, limit=0, fields='*', format='application/solr+json', query='*', distrib=False, type='Dataset', constraints='None', esgf=False, list_t
   ?           +    +                     ^        ^                                                                 ^^^^                               +    +       ^^^^
```

Passing Jenkins run http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/master/343/