### PR TITLE
finch.ipynb: ignore output in last print(log) to fix intermittent Jenkins failure

### DIFF
--- a/docs/source/notebooks/finch.ipynb
+++ b/docs/source/notebooks/finch.ipynb
@@ -245,6 +245,7 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print(log)"
    ]
   }
@@ -265,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
On slow system, intermittently, we see this Jenkins error (note the "32% Done"
line added):

```
  _________ pavics-sdi-master/docs/source/notebooks/finch.ipynb::Cell 7 __________
  Notebook cell execution failed
  Cell 7: Cell outputs differ

  Input:
  print(log)

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    'Processing s...cessfully\n\n' == 'Processing s...cessfully\n\n'
    Skipping 261 identical leading characters in diff, use -v to show
      1.0s
    + [####           ] | 32% Done |100% Done |  1.0s
      [###############] | 100% Done |  1.0s|100% Done |  1.0s
      Processing finished successfully
```