### PR TITLE
catalog_search.ipynb: fix jenkins failure after new crawl

### DIFF
--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -97,8 +97,13 @@
       "text/plain": [
        "['https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
        " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r2i1p1/tasmin/tasmin_day_CanESM2_rcp85_r2i1p1_20060101-21001231.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_CanESM2_rcp85_r1i1p1_20060101-21001231.nc',\n",
        " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_CanESM2_rcp85_r3i1p1_20060101-21001231.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
        " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r4i1p1/tasmin/tasmin_day_CanESM2_rcp85_r4i1p1_20060101-21001231.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r2i1p1/tasmin/tasmin_day_CanESM2_rcp85_r2i1p1_20060101-21001231.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r4i1p1/tasmin/tasmin_day_CanESM2_rcp85_r4i1p1_20060101-21001231.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_CanESM2_rcp85_r3i1p1_20060101-21001231.nc',\n",
        " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_CanESM2_rcp85_r1i1p1_20060101-21001231.nc']"
       ]
      },
@@ -108,14 +113,14 @@
     }
    ],
    "source": [
-    "resp = wps.pavicsearch(constraints=\"variable:tasmin,project:CMIP5,experiment:rcp85,frequency:day\", limit=10, type=\"File\")\n",
+    "resp = wps.pavicsearch(constraints=\"variable:tasmin,project:CMIP5,experiment:rcp85,frequency:day,institute:CCCma,model:CanESM2\", limit=10, type=\"File\")\n",
     "[result, files] = resp.get(asobj=True)\n",
     "files"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -166,7 +171,7 @@
        " 'fileserver_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc'}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,6 +179,13 @@
    "source": [
     "result['response']['docs'][0]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -192,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Make the query much more precise by adding "institute:CCCma,model:CanESM2".

Previous query was returning 200+ results after new crawl triggered in https://github.com/bird-house/birdhouse-deploy/pull/4#issuecomment-587163363.

Now we seems to have duplicate result, "cccma" and "CCCMA".  @huard did we rename "CCCMA" to "cccma" on Thredds?

New working Jenkins run: http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/master/480/console

Jenkins error fixed:

```
00:35:48  _____ pavics-sdi-master/docs/source/notebooks/catalog_search.ipynb::Cell 1 _____
00:35:48  Notebook cell execution failed
00:35:48  Cell 1: Cell outputs differ
00:35:48
00:35:48  Input:
00:35:48  resp = wps.pavicsearch(constraints="variable:tasmin,project:CMIP5,experiment:rcp85,frequency:day", limit=10, type="File")
00:35:48  [result, files] = resp.get(asobj=True)
00:35:48  files
00:35:48
00:35:48  Traceback:
00:35:48   mismatch 'text/plain'
00:35:48
00:35:48   assert reference_output == test_output failed:
00:35:48
00:35:48    "['https://pa...21001231.nc']" == "['https://pa...20101130.nc']"
00:35:48    Skipping 61 identical leading characters in diff, use -v to show
00:35:48    - birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?           ^^^ ^^^^^^^^^                  ^                        ^^^^ ^        ^       ^
00:35:48    + birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?           ^^^^^^ ^^                  ^                       ++++ ^^ ^        ^       ^
00:35:48    -  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r2i1p1/tasmin/tasmin_day_CanESM2_rcp85_r2i1p1_20060101-21001231.nc',
00:35:48    ?                                                                        ^^^ ^ ^^^   ^                  ^                       ^^^   ^        ^       --       ^^
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MPI-M/MPI-ESM-LR/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MPI-ESM-LR_rcp85_r1i1p1_21300101-21391231.nc',
00:35:48    ?                                                                        ^^^^^^ ^^^^ ^^^^   ^^^                  ^                       ^^^^   ^^^        ^      ++        ^^
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MPI-M/MPI-ESM-LR/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MPI-ESM-LR_rcp85_r1i1p1_21810101-21891231.nc',
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MOHC/HadGEM2-ES/rcp85/day/atmos/r4i1p1/tasmin/tasmin_day_HadGEM2-ES_rcp85_r4i1p1_20951201-21001130.nc',
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MOHC/HadGEM2-CC/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_HadGEM2-CC_rcp85_r1i1p1_20451201-20501130.nc',
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MOHC/HadGEM2-ES/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_HadGEM2-ES_rcp85_r1i1p1_20401201-20451130.nc',
00:35:48    -  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_CanESM2_rcp85_r3i1p1_20060101-21001231.nc',
00:35:48    ?                                                                        ^^^ ^ ^^^   ^                                          ^^^   ^                 -      - ^
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MPI-M/MPI-ESM-LR/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_MPI-ESM-LR_rcp85_r3i1p1_20400101-20491231.nc',
00:35:48    ?                                                                        ^^^^^^ ^^^^ ^^^^   ^^^                                          ^^^^   ^^^                +        ^^
00:35:48    -  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r4i1p1/tasmin/tasmin_day_CanESM2_rcp85_r4i1p1_20060101-21001231.nc',
00:35:48    -  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_CanESM2_rcp85_r1i1p1_20060101-21001231.nc']
00:35:48    ?                                                                         ^^ ^^^^^  --                                          ^ ^  --                ---     -   ^ ^    ^
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MOHC/HadGEM2-ES/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_HadGEM2-ES_rcp85_r1i1p1_20151201-20201130.nc',
00:35:48    ?                                                                        +++++++++ ^^^^^^ ^^                                            ^ ^^^^^^                   +++     +  ^ ^    ^^
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MOHC/HadGEM2-ES/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_HadGEM2-ES_rcp85_r1i1p1_22191201-22291130.nc',
00:35:48    +  'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MOHC/HadGEM2-CC/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_HadGEM2-CC_rcp85_r3i1p1_20051201-20101130.nc']
00:35:48
00:35:48
00:35:48  _____ pavics-sdi-master/docs/source/notebooks/catalog_search.ipynb::Cell 2 _____
00:35:48  Notebook cell execution failed
00:35:48  Cell 2: Cell outputs differ
00:35:48
00:35:48  Input:
00:35:48  result['response']['docs'][0]
00:35:48
00:35:48  Traceback:
00:35:48   mismatch 'text/plain'
00:35:48
00:35:48   assert reference_output == test_output failed:
00:35:48
00:35:48    "{'cf_standar...21001231.nc'}" == "{'cf_standar...21001231.nc'}"
00:35:48    Skipping 56 identical leading characters in diff, use -v to show
00:35:48    - birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?           ^^^ ^^^^^^^^^                  ^                        ^^^^ ^        ^       ^
00:35:48    + birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?           ^^^^^^ ^^                  ^                       ++++ ^^ ^        ^       ^
00:35:48       'replica': False,
00:35:48    -  'wms_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?                                                                                                                                        ^^^^^^^^^^^^^                  ^                       ^^^^^^^        ^^^^^^^^^
00:35:48    +  'wms_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?                                                                                                                                        ^^^^^^^^^                  ^                       ^^^^^^^^^        ^^^^^^^^^
00:35:48       'keywords': ['air_temperature',
00:35:48        'day',
00:35:48        'application/netcdf',
00:35:48        'tasmin',
00:35:48        'thredds',
00:35:48        'CMIP5',
00:35:48        'rcp85',
00:35:48    -   'CanESM2',
00:35:48    -   'CCCma'],
00:35:48    +   'MRI-CGCM3',
00:35:48    +   'MRI'],
00:35:48    -  'dataset_id': 'CCCMA.CanESM2.rcp85.day.atmos.r5i1p1.tasmin',
00:35:48    ?                 ^^^ ^^^^^^^^^                  ^
00:35:48    +  'dataset_id': 'cmip5.MRI.rcp85.day.atmos.r1i1p1.tasmin',
00:35:48    ?                 ^^^^^^ ^^                  ^
00:35:48       'datetime_max': 'DATE_TIME_TZ',
00:35:48    -  'id': '29186a2db2230376',
00:35:48    +  'id': '0035405c47cd3a2f',
00:35:48       'subject': 'Birdhouse Thredds Catalog',
00:35:48       'category': 'thredds',
00:35:48    -  'opendap_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?                                                                                       ^^^ ^^^^^^^^^                  ^                        ^^^^ ^        ^       ^
00:35:48    +  'opendap_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?                                                                                       ^^^^^^ ^^                  ^                       ++++ ^^ ^        ^       ^
00:35:48    -  'title': 'tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?                        ^^^^ ^        ^       ^
00:35:48    +  'title': 'tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?                       ++++ ^^ ^        ^       ^
00:35:48       'variable_palette': ['default'],
00:35:48       'variable_min': [0],
00:35:48       'variable_long_name': ['Daily Minimum Near-Surface Air Temperature'],
00:35:48    -  'source': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog.xml',
00:35:48    +  'source': 'https://pavics.ouranos.ca//twitcher/ows/proxy/thredds/catalog.xml',
00:35:48    ?                                      +
00:35:48       'datetime_min': 'DATE_TIME_TZ',
00:35:48       'score': 1.0,
00:35:48       'variable_max': [1],
00:35:48       'units': ['K'],
00:35:48    -  'resourcename': 'birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?                             ^^^ ^^^^^^^^^                  ^                        ^^^^ ^        ^       ^
00:35:48    +  'resourcename': 'birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?                             ^^^^^^ ^^                  ^                       ++++ ^^ ^        ^       ^
00:35:48       'type': 'File',
00:35:48    -  'catalog_url': 'https://pavics.ouranos.ca/thredds/catalog/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/catalog.xml?dataset=birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    +  'catalog_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/catalog.xml?dataset=birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48       'experiment': 'rcp85',
00:35:48       'last_modified': 'DATE_TIME_TZ',
00:35:48       'content_type': 'application/netcdf',
00:35:48    -  '_version_': 1599589044577107972,
00:35:48    +  '_version_': 1658705770170023939,
00:35:48       'variable': ['tasmin'],
00:35:48    -  'url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',
00:35:48    ?                                                                                    ^^^ ^^^^^^^^^                  ^                        ^^^^ ^        ^       ^
00:35:48    +  'url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc',
00:35:48    ?                                                                                    ^^^^^^ ^^                  ^                       ++++ ^^ ^        ^       ^
00:35:48       'project': 'CMIP5',
00:35:48    -  'institute': 'CCCma',
00:35:48    ?                ^^^^^
00:35:48    +  'institute': 'MRI',
00:35:48    ?                ^^^
00:35:48       'frequency': 'day',
00:35:48    -  'model': 'CanESM2',
00:35:48    +  'model': 'MRI-CGCM3',
00:35:48       'latest': True,
00:35:48    -  'fileserver_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc'}
00:35:48    ?                                                                                               ^^^ ^^^^^^^^^                  ^                        ^^^^ ^        ^       ^
00:35:48    +  'fileserver_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/cmip5/MRI/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_MRI-CGCM3_rcp85_r1i1p1_20960101-21001231.nc'}
00:35:48    ?                                                                                               ^^^^^^ ^^                  ^                       ++++ ^^ ^        ^       ^
00:35:48
```