### PR TITLE
Remove hardcode public/public JupyterLab login since it is now configurable for security reasons

### DIFF
--- a/docs/source/arch/jupyter.rst
+++ b/docs/source/arch/jupyter.rst
@@ -2,11 +2,13 @@
 JupyterLab Interface
 ====================
 
-A `JupyterLab`_ instance runs on the PAVICS server at `<pavics.ouranos.ca/jupyter>`_. The intent is not to run production code, but rather to demo the backend services available from a programming environment. The Python 3 engine has a number of libraries pre-installed, making it easy to experiment with web processing services and netCDF files.
+A `JupyterLab`_ instance runs on the PAVICS server at `<pavics.ouranos.ca/jupyter>`_.  The Python 3 engine has a number of libraries pre-installed, making it easy to experiment with web processing services and netCDF files.
 
-Users should connect with the `public` login and the `public` password. User accounts will be available at a later time. Meanwhile, save your work elsewhere, because the user-created notebooks will be erased periodically.
+There is a demo account, contact the support email on the login screen to get the password.  This demo account has limitted computing resources, for security reasons.  Any files created in the demo account is visible and editable to all users having access to the demo account.
 
-A number of tutorial notebooks are available in the public directory to give a sense of how services can be  used in scientific workflows. These notebooks are tested daily against the production server.
+For production usage, without computing resource limitation and with private user workspace, request your own user account using the support email on the login screen.
+
+A number of tutorial notebooks are available in each user workspace to give a sense of how services can be used in scientific workflows. These notebooks are tested daily against the production server and kept up-to-date automatically.
 
 
 .. _JupyterLab: https://jupyterlab.readthedocs.io/en/stable/

--- a/docs/source/arch/jupyter.rst
+++ b/docs/source/arch/jupyter.rst
@@ -2,9 +2,9 @@
 JupyterLab Interface
 ====================
 
-A `JupyterLab`_ instance runs on the PAVICS server at `<pavics.ouranos.ca/jupyter>`_.  The Python 3 engine has a number of libraries pre-installed, making it easy to experiment with web processing services and netCDF files.
+A `JupyterLab`_ instance runs on the PAVICS server at `<pavics.ouranos.ca/jupyter>`_. The Python3 engine has a number of libraries pre-installed, making it easy to experiment with web processing services and netCDF files.
 
-There is a demo account, contact the support email on the login screen to get the password.  This demo account has limitted computing resources, for security reasons.  Any files created in the demo account is visible and editable to all users having access to the demo account.
+There is a demo account available for those interested in testing its capabilities. Contact the support email on the login screen to get the password. This demo account has limited computing resources, for security reasons. Any files created using the demo account are visible and modifiable by all users having access to the demo account.
 
 For production usage, without computing resource limitation and with private user workspace, request your own user account using the support email on the login screen.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@
 PAVICS is a research platform dedicated to climate analysis and visualization. It bundles
 data search, analytics and visualization services. PAVICS is developped by Ouranos, CRIM and the `birdhouse`_ community and been funded by the `CANARIE`_ research software program.
 
-To get a sense of what the platform can do, check out our `JupyterLab`_ environment (login/passwd: public/public).
+To get a sense of what the platform can do, check out our `JupyterLab`_ environment.
 
 Documentation structure
 -----------------------


### PR DESCRIPTION
Computing resources of the demo account has also been limitted for security reasons.

See PR https://github.com/bird-house/birdhouse-deploy/pull/35 (commit https://github.com/bird-house/birdhouse-deploy/commit/63c8c356f0eadb3b0cf9fb4eea4fff6846bb5d78).