### PR TITLE
catalog_search.ipynb: rewrite query so the data needed on Thredds server is minimum

### DIFF
--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -113,6 +113,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "resp = wps.pavicsearch(constraints=\"variable:tasmin,project:CMIP5,experiment:rcp85,frequency:day,institute:CCCma,model:CanESM2\", limit=10, type=\"File\")\n",
     "[result, files] = resp.get(asobj=True)\n",
     "files"
@@ -177,6 +179,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "result['response']['docs'][0]"
    ]
   },

--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -207,7 +207,6 @@
       "variable_palette: ['default']\n",
       "variable_min: [0]\n",
       "variable_long_name: ['Daily Maximum Near-Surface Air Temperature']\n",
-      "source: https://pavics.ouranos.ca//twitcher/ows/proxy/thredds/catalog.xml\n",
       "datetime_min: 2006-01-16T12:00:00Z\n",
       "score: 1.0\n",
       "variable_max: [1]\n",
@@ -231,7 +230,7 @@
    "source": [
     "for k in searchfile[0].keys():\n",
     "    # remove attributes that changes between different servers for the same file\n",
-    "    if k not in ['id','last_modified','_version_']:\n",
+    "    if k not in ['id', 'last_modified', '_version_', 'source']:\n",
     "        print(f\"{k}: {searchfile[0][k]}\")"
    ]
   },

--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -95,16 +95,15 @@
     {
      "data": {
       "text/plain": [
-       "['https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r2i1p1/tasmin/tasmin_day_CanESM2_rcp85_r2i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_CanESM2_rcp85_r1i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_CanESM2_rcp85_r3i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r4i1p1/tasmin/tasmin_day_CanESM2_rcp85_r4i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r2i1p1/tasmin/tasmin_day_CanESM2_rcp85_r2i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r4i1p1/tasmin/tasmin_day_CanESM2_rcp85_r4i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cccma/CanESM2/rcp85/day/atmos/r3i1p1/tasmin/tasmin_day_CanESM2_rcp85_r3i1p1_20060101-21001231.nc',\n",
-       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r1i1p1/tasmin/tasmin_day_CanESM2_rcp85_r1i1p1_20060101-21001231.nc']"
+       "['https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MPI-M/MPI-ESM-MR/rcp45/mon/atmos/r2i1p1/tasmax/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-210012.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200601-200612.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200701-200712.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MPI-M/MPI-ESM-MR/rcp45/mon/atmos/r3i1p1/tasmax/tasmax_Amon_MPI-ESM-MR_rcp45_r3i1p1_200601-210012.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200601-200612.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200701-200712.nc',\n",
+       " 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/cmip5/MPI-M/MPI-ESM-MR/rcp45/mon/atmos/r1i1p1/tasmax/tasmax_Amon_MPI-ESM-MR_rcp45_r1i1p1_200601-210012.nc']"
       ]
      },
      "execution_count": 2,
@@ -115,7 +114,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "resp = wps.pavicsearch(constraints=\"variable:tasmin,project:CMIP5,experiment:rcp85,frequency:day,institute:CCCma,model:CanESM2\", limit=10, type=\"File\")\n",
+    "resp = wps.pavicsearch(constraints=\"variable:tasmax,project:CMIP5,experiment:rcp45,model:MPI-ESM-MR,institute:MPI-M,frequency:mon\", limit=10, type=\"File\")\n",
     "[result, files] = resp.get(asobj=True)\n",
     "files"
    ]
@@ -129,48 +128,48 @@
      "data": {
       "text/plain": [
        "{'cf_standard_name': ['air_temperature'],\n",
-       " 'abstract': 'birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
+       " 'abstract': 'birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
        " 'replica': False,\n",
-       " 'wms_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
+       " 'wms_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
        " 'keywords': ['air_temperature',\n",
-       "  'day',\n",
+       "  'mon',\n",
        "  'application/netcdf',\n",
-       "  'tasmin',\n",
+       "  'tasmax',\n",
        "  'thredds',\n",
        "  'CMIP5',\n",
-       "  'rcp85',\n",
-       "  'CanESM2',\n",
-       "  'CCCma'],\n",
-       " 'dataset_id': 'CCCMA.CanESM2.rcp85.day.atmos.r5i1p1.tasmin',\n",
-       " 'datetime_max': '2100-12-31T12:00:00Z',\n",
-       " 'id': '29186a2db2230376',\n",
+       "  'rcp45',\n",
+       "  'MPI-ESM-MR',\n",
+       "  'MPI-M'],\n",
+       " 'dataset_id': 'testdata.flyingpigeon.cmip5',\n",
+       " 'datetime_max': '2006-12-16T12:00:00Z',\n",
+       " 'id': '44b680cec0a7d4cc',\n",
        " 'subject': 'Birdhouse Thredds Catalog',\n",
        " 'category': 'thredds',\n",
-       " 'opendap_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
-       " 'title': 'tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
+       " 'opendap_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
+       " 'title': 'tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
        " 'variable_palette': ['default'],\n",
        " 'variable_min': [0],\n",
-       " 'variable_long_name': ['Daily Minimum Near-Surface Air Temperature'],\n",
-       " 'source': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog.xml',\n",
-       " 'datetime_min': '2006-01-01T12:00:00Z',\n",
+       " 'variable_long_name': ['Daily Maximum Near-Surface Air Temperature'],\n",
+       " 'source': 'https://pavics.ouranos.ca//twitcher/ows/proxy/thredds/catalog.xml',\n",
+       " 'datetime_min': '2006-01-16T12:00:00Z',\n",
        " 'score': 1.0,\n",
        " 'variable_max': [1],\n",
        " 'units': ['K'],\n",
-       " 'resourcename': 'birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
+       " 'resourcename': 'birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
        " 'type': 'File',\n",
-       " 'catalog_url': 'https://pavics.ouranos.ca/thredds/catalog/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/catalog.xml?dataset=birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
-       " 'experiment': 'rcp85',\n",
-       " 'last_modified': '2018-04-04T15:10:30Z',\n",
+       " 'catalog_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/flyingpigeon/cmip5/catalog.xml?dataset=birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
+       " 'experiment': 'rcp45',\n",
+       " 'last_modified': '2018-12-21T15:13:38Z',\n",
        " 'content_type': 'application/netcdf',\n",
-       " '_version_': 1599589044577107972,\n",
-       " 'variable': ['tasmin'],\n",
-       " 'url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc',\n",
+       " '_version_': 1658705594373111809,\n",
+       " 'variable': ['tasmax'],\n",
+       " 'url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',\n",
        " 'project': 'CMIP5',\n",
-       " 'institute': 'CCCma',\n",
-       " 'frequency': 'day',\n",
-       " 'model': 'CanESM2',\n",
+       " 'institute': 'MPI-M',\n",
+       " 'frequency': 'mon',\n",
+       " 'model': 'MPI-ESM-MR',\n",
        " 'latest': True,\n",
-       " 'fileserver_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/CCCMA/CanESM2/rcp85/day/atmos/r5i1p1/tasmin/tasmin_day_CanESM2_rcp85_r5i1p1_20060101-21001231.nc'}"
+       " 'fileserver_url': 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc'}"
       ]
      },
      "execution_count": 3,
@@ -181,7 +180,59 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "result['response']['docs'][0]"
+    "searchfile = [f for f in result['response']['docs'] if f['resourcename'] == 'birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc']\n",
+    "searchfile[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cf_standard_name: ['air_temperature']\n",
+      "abstract: birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "replica: False\n",
+      "wms_url: https://pavics.ouranos.ca/twitcher/ows/proxy/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "keywords: ['air_temperature', 'mon', 'application/netcdf', 'tasmax', 'thredds', 'CMIP5', 'rcp45', 'MPI-ESM-MR', 'MPI-M']\n",
+      "dataset_id: testdata.flyingpigeon.cmip5\n",
+      "datetime_max: 2006-12-16T12:00:00Z\n",
+      "subject: Birdhouse Thredds Catalog\n",
+      "category: thredds\n",
+      "opendap_url: https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "title: tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "variable_palette: ['default']\n",
+      "variable_min: [0]\n",
+      "variable_long_name: ['Daily Maximum Near-Surface Air Temperature']\n",
+      "source: https://pavics.ouranos.ca//twitcher/ows/proxy/thredds/catalog.xml\n",
+      "datetime_min: 2006-01-16T12:00:00Z\n",
+      "score: 1.0\n",
+      "variable_max: [1]\n",
+      "units: ['K']\n",
+      "resourcename: birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "type: File\n",
+      "catalog_url: https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/birdhouse/testdata/flyingpigeon/cmip5/catalog.xml?dataset=birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "experiment: rcp45\n",
+      "content_type: application/netcdf\n",
+      "variable: ['tasmax']\n",
+      "url: https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n",
+      "project: CMIP5\n",
+      "institute: MPI-M\n",
+      "frequency: mon\n",
+      "model: MPI-ESM-MR\n",
+      "latest: True\n",
+      "fileserver_url: https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/fileServer/birdhouse/testdata/flyingpigeon/cmip5/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "for k in searchfile[0].keys():\n",
+    "    # remove attributes that changes between different servers for the same file\n",
+    "    if k not in ['id','last_modified','_version_']:\n",
+    "        print(f\"{k}: {searchfile[0][k]}\")"
    ]
   },
   {
@@ -208,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -114,7 +114,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "resp = wps.pavicsearch(constraints=\"variable:tasmax,project:CMIP5,experiment:rcp45,model:MPI-ESM-MR,institute:MPI-M,frequency:mon\", limit=10, type=\"File\")\n",
+    "resp = wps.pavicsearch(constraints=\"variable:tasmax,project:CMIP5,experiment:rcp45,model:MPI-ESM-MR,institute:MPI-M,frequency:mon\", limit=100, type=\"File\")\n",
     "[result, files] = resp.get(asobj=True)\n",
     "files"
    ]


### PR DESCRIPTION
Fixes https://github.com/Ouranosinc/pavics-sdi/issues/147

This notebook is a good round trip testing for
* crawler can crawl data on Thredds
* crawler can insert proper data in Solr DB
* catalog search is able to query Solr DB to retrieve the expected data

With the query requiring only the minimum data on Thredds that was already needed by other notebooks, this notebook should pass on all deployments of PAVICS given the minimum test data is available and the crawler has been triggered.