### PR TITLE
Notebook extensions

### DIFF
--- a/docs/source/notebooks/jupyter_extensions.ipynb
+++ b/docs/source/notebooks/jupyter_extensions.ipynb
@@ -120,7 +120,7 @@
     "The jupyter_conda page can be opened by selecting \"Settings\" --> \"Conda Packages Manager\", via the top menu bar.\n",
     "You can then see the list of Conda environments available, and the list of \"Installed\" and \"Not installed\" packages in each environment.\n",
     "\n",
-    "**Note that it can take a certain time to see the list of \"Not installed\" packages, as the extension loads all the available Conda packages from the different channels.**\n",
+    "**Note that it can take a certain time to see the list of \"Not installed\" packages, as the extension loads all the available Conda packages from the different channels. Also, the \"Not installed\" list is not exhaustive. For example, pypi packages do not appear here. If a package is not found in this list, you can still install it via a notebook cell, and the package should now appear in the \"Installed\" list.**\n",
     "\n",
     "You can install/update/remove packages via this interface.\n",
     "\n",

--- a/docs/source/notebooks/jupyter_extensions.ipynb
+++ b/docs/source/notebooks/jupyter_extensions.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# JupyterLab Extensions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebooks Versioning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### jupyterlab-git "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extension is used to include Git in the JupyterLab's environment. \n",
+    "\n",
+    "It adds a new \"Git\" button on the top menu bar, to use Git's main features (init, clone, push, pull). Note that it also includes an option to open a Git terminal, in order to use Git commands via a terminal interface. If clicking on this \"Open Git Repository in Terminal\" option does not do anything, it means terminal access has been restricted for your user and this option cannot be used in this case.\n",
+    "\n",
+    "The user can also Clone a new repository from the File Browser panel with the provided button.\n",
+    "\n",
+    "Another way to interact with Git is via a new button on the left sidebar, which will open a Git panel. This panel will let the user init and clone a repo, and, once a repo is opened via the File Browser, the user will be able to manage his branches and commits. \n",
+    "\n",
+    "A 'Changes' tab can be used to see the Staged/Changed/Untracked files. For each Changed file, we can open a diff page showing side by side the differences between the original and the modified file.\n",
+    "\n",
+    "There is also a 'History' tab which displays the past commits, and the changed files can be opened to see the diff of the associated commit. \n",
+    "\n",
+    "Github page : https://github.com/jupyterlab/jupyterlab-git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### jupytext"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extension is mostly useful in conjonction with the jupyterlab-git extension.\n",
+    "It will pair your notebook .ipynb file with an additional file format. It can be used, for example, to pair the notebook with a python script, that contains only the code found in the notebook's cells, and we can choose to version only this new .py file on Git, to avoid the problem of conflicts often found on a notebook cell output.\n",
+    "\n",
+    "You can use jupytext via the \"Commands\" button on the left side bar. You will find in the \"Commands\" panel a section dedicated to jupytext, offering a choice of different file pairing formats. \n",
+    "\n",
+    "The main types of format are either a script file (.py) or a markdown file (.md). There are multiple choices for each type, depending of how you want to handle cell markers and cell outputs. \n",
+    "\n",
+    "Check the doc on the Github page for a description of the different file formats :\n",
+    "https://github.com/mwouts/jupytext#which-text-format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### jupyterlab-google-drive"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extension adds a Google Drive file browser to the Jupyterlab environment, useful as an alternative to using Git versioning.\n",
+    "\n",
+    "The user only needs to open the Google Drive tab via the button found on the left side bar and then, to login to his Google account.\n",
+    "When logged in, the user will see his files found on his Google Drive. \n",
+    "To create a new file, make sure to be in a writable folder.\n",
+    "\n",
+    "There is also an \"Upload\" button to add an existing notebook from your local system.\n",
+    "\n",
+    "If you want to add an existing notebook from the File Browser panel to the Google Drive panel, there is no direct way to do it. The user must either :\n",
+    "- create a new notebook in the Google Drive panel and copy/paste the content of the existing notebook to the new one\n",
+    "- download the existing notebook, add it to Google Drive via the Google Drive website and refresh the Google Drive panel in JupyterLab to see the added file\n",
+    "\n",
+    "**Note that versioning is limited with this extension** :<br>\n",
+    "This extension doesn't have any option to go back to a previous version. The user will have to do this via the Google Drive website. Also, Google keeps previous versions of \"non-Google files\" (such as the .ipynb notebook format) only for 30 days, or up to a maximum of 100 versions. <br>\n",
+    "Also, going back to a previous versions requires multiple steps (on the Google Drive website) :\n",
+    "- Right-click on file + \"Manage versions\"\n",
+    "- Download the desired previous version\n",
+    "- Still on the \"Manage versions\" window, click \"Upload new version\" and select the downloaded file from last step\n",
+    "\n",
+    "**Known issue** : At the top of the panel, there are 5 buttons for the extension, but the fifth one (Sign Out button) doesn't have an icon.\n",
+    "\n",
+    "Github page : https://github.com/jupyterlab/jupyterlab-google-drive"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Managing packages and conda environments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### jupyter_conda"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extension adds a page to manage installed packages and Conda environments.\n",
+    "\n",
+    "The jupyter_conda page can be opened by selecting \"Settings\" --> \"Conda Packages Manager\", via the top menu bar.\n",
+    "You can then see the list of Conda environments available, and the list of \"Installed\" and \"Not installed\" packages in each environment.\n",
+    "\n",
+    "**Note that it can take a certain time to see the list of \"Not installed\" packages, as the extension loads all the available Conda packages from the different channels.**\n",
+    "\n",
+    "You can install/update/remove packages via this interface.\n",
+    "\n",
+    "A new environment can be imported from an .yml file, or an environment can be exported to an .yml file via the available buttons.\n",
+    "\n",
+    "When using your own environment, make sure to include the **ipykernel** and **nb_conda kernels** packages. They are required if we want to use the environment in a notebook. Activating those packages will make the environment available in the Kernel selection button at the top right of a notebook page. The user must be able to select the environment's kernel in order to run cells with the environment's packages.\n",
+    "\n",
+    "If a user wants to install a package via a cell (instead of using the extension's interface), it is recommanded to run the instruction using the '%' token. It is also a good idea to include the environment name in argument to avoid any confusion. \n",
+    "\n",
+    "Example : %conda install -y -n 'environment_name' 'packge_name'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/notebooks/jupyter_extensions.ipynb
+++ b/docs/source/notebooks/jupyter_extensions.ipynb
@@ -130,7 +130,7 @@
     "\n",
     "If a user wants to install a package via a cell (instead of using the extension's interface), it is recommanded to run the instruction using the '%' token. It is also a good idea to include the environment name in argument to avoid any confusion. \n",
     "\n",
-    "Example : %conda install -y -n 'environment_name' 'packge_name'"
+    "Example : %conda install -y -n 'environment_name' 'package_name'"
    ]
   },
   {

--- a/docs/source/notebooks/jupyter_extensions.ipynb
+++ b/docs/source/notebooks/jupyter_extensions.ipynb
@@ -132,7 +132,9 @@
     "\n",
     "If a user wants to install a package via a cell (instead of using the extension's interface), it is recommanded to run the instruction using the '%' token. It is also a good idea to include the environment name in argument to avoid any confusion. \n",
     "\n",
-    "Example : %conda install -y -n 'environment_name' 'package_name'"
+    "Example : %conda install -y -n 'environment_name' 'package_name'\n",
+    "\n",
+    "Github page: https://github.com/mamba-org/gator"
    ]
   },
   {
@@ -159,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/jupyter_extensions.ipynb
+++ b/docs/source/notebooks/jupyter_extensions.ipynb
@@ -37,6 +37,8 @@
     "\n",
     "There is also a 'History' tab which displays the past commits, and the changed files can be opened to see the diff of the associated commit. \n",
     "\n",
+    "**Warning: Avoid using the \"git config credential.helper store\" command as it could save and expose your git credentials (including your username and your password) in a file in your user directory, which would be accessible by administrators.**\n",
+    "\n",
     "Github page : https://github.com/jupyterlab/jupyterlab-git"
    ]
   },


### PR DESCRIPTION
Documentation for the new jupyterlab extensions we are adding
This notebook will give easily accessable documentation for the user, and will give an overview of what he can do with the extensions.

Matching PR Ouranosinc/PAVICS-e2e-workflow-tests#54 for the new image with 4 new extensions: jupytext, jupyterlab-google-drive, jupyter_conda and jupyterlab-git

Matching PR bird-house/birdhouse-deploy#97 for jupyterlab-google-drive deployment config.