### PR TITLE
catalog_search.ipynb: fix help() output change that broke Jenkins

### DIFF
--- a/docs/source/notebooks/catalog_search.ipynb
+++ b/docs/source/notebooks/catalog_search.ipynb
@@ -20,7 +20,7 @@
      "text": [
       "Help on method pavicsearch in module birdy.client.base:\n",
       "\n",
-      "pavicsearch(facets='None', shards='*', offset=0, limit=0, fields='*', format='application/solr+json', query='*', distrib=False, type='Dataset', constraints='None', esgf=False, list_type='opendap_url') method of birdy.client.base.WPSClient instance\n",
+      "pavicsearch(facets=None, shards='*', offset=0, limit=0, fields='*', format='application/solr+json', query='*', distrib=False, type='Dataset', constraints=None, esgf=False, list_type='opendap_url') method of birdy.client.base.WPSClient instance\n",
       "    Search the PAVICS database and return a catalogue of matches.\n",
       "    \n",
       "    Parameters\n",


### PR DESCRIPTION
The change is 'None' to None (without the surrounding quote).

Jenkins error due to upgrade from pavics/workflow-tests:201111 to pavics/workflow-tests:201214 (PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/56)

```
  _____ pavics-sdi-master/docs/source/notebooks/catalog_search.ipynb::Cell 0 _____
  Notebook cell execution failed
  Cell 0: Cell outputs differ

  Input:
  import collections
  from birdy import WPSClient
  url = "https://pavics.ouranos.ca/twitcher/ows/proxy/catalog/wps"
  wps = WPSClient(url)
  help(wps.pavicsearch)

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    'Help on meth...h result.\n\n' == 'Help on meth...h result.\n\n'
    Skipping 66 identical leading characters in diff, use -v to show
    - ch(facets=None, shards='*', offset=0, limit=0, fields='*', format='application/solr+json', query='*', distrib=False, type='Dataset', constraints=None, esgf=False, list_type='opendap_url') method of birdy.client.base.WPSClient instance
    ?               ^                                                                                                                                      ^
    + ch(facets='None', shards='*', offset=0, limit=0, fields='*', format='application/solr+json', query='*', distrib=False, type='Dataset', constraints='None', esgf=False, list_type='opendap_url') method of birdy.client.base.WPSClient instance
    ?           +    ^^                                                                                                                                  +    ^^
          Search the PAVICS database and return a catalogue of matches.

          Parameters
          ----------
          facets : string
              Comma separated list of facets; facets are searchable indexing terms in the database.
          shards : string
              Shards to be queried
```