### PR TITLE
add the readthedocs link to top readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,4 @@ pavics-sdi
 Power Analytics and Visualization for Climate Science - Spatial Data Infrastructure
 
 Check out the `official documentation <https://ouranosinc.github.io/pavics-sdi/>`_.
+Check out the `latest documentation <https://pavics-sdi.readthedocs.io>`_.


### PR DESCRIPTION
Top level link refers to really out of date docs compared to repo content. 
Add it for quick reference. 