### PR TITLE
WMS_example.ipynb: ignore output to not break Jenkins in the future for similar change

### DIFF
--- a/docs/source/notebooks/WMS_example.ipynb
+++ b/docs/source/notebooks/WMS_example.ipynb
@@ -134,6 +134,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "from IPython.core.display import HTML\n",
     "\n",
     "name = 'MOD_143D_RR'\n",
@@ -273,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For this Jenkins build error (a new `layer.timepositions` is available):
```
  ______ pavics-sdi-master/docs/source/notebooks/WMS_example.ipynb::Cell 3 _______
  Notebook cell execution failed
  Cell 3: Cell outputs differ

  Input:
  from IPython.core.display import HTML

  name = 'MOD_143D_RR'
  layer = wms.contents[name]
  print("Abstract: ", layer.abstract)
  print("BBox: ", layer.boundingBoxWGS84)
  print("CRS: ", layer.crsOptions)
  print("Styles: ", layer.styles)
  print("Timestamps: ", layer.timepositions)
  HTML(layer.parent.abstract)

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    "Abstract:  N.../DATE/P1D']\n" == "Abstract:  N...021-04-20']\n"
    Skipping 956 identical leading characters in diff, use -v to show
    - /DATE/P1D', '2021-04-20']
    + /DATE/P1D']
```