### PR TITLE
subset-user-input.ipynb: fix for Jenkins to run against test servers

### DIFF
--- a/docs/source/notebooks/subset-user-input.ipynb
+++ b/docs/source/notebooks/subset-user-input.ipynb
@@ -491,9 +491,7 @@
    ],
    "source": [
     "# gather data from pavics' data catalogue\n",
-    "catalog = (\n",
-    "    f\"{pavics_url}/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml\"\n",
-    ")\n",
+    "catalog = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml\"  # TEST_USE_PROD_DATA\n",
     "\n",
     "cat = TDSCatalog(catalog)\n",
     "data = cat.datasets[0].access_urls[\"OPENDAP\"]\n",


### PR DESCRIPTION
Any NCML catalogs have to come from the production server since that's too much data to replicate to all the various test servers.

So the catalog string have to hardcode `pavics.ouranos.ca` and use the marker `TEST_USE_PROD_DATA`, all on the same line.

Fix this kind of error:
```
OSError: [Errno -70] NetCDF: DAP server error: b'https://medus.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml'
```

Also require corresponding PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/86 to work properly.