### PR TITLE
pavics_thredds.ipynb: update for new Jupyter env with xarray 0.20.1

### DIFF
--- a/docs/source/notebooks/pavics_thredds.ipynb
+++ b/docs/source/notebooks/pavics_thredds.ipynb
@@ -616,8 +616,10 @@
     "try:\n",
     "    ds = xr.open_dataset(SECURED_URL, decode_cf=False)\n",
     "# depending on 'xarray' version, differnt errors are raised when failing authentication according on how they handle it\n",
-    "except OSError as exc:  # xarray < 0.17\n",
-    "    assert \"Authorization failure\" in str(exc)\n",
+    "except OSError as exc:\n",
+    "    # \"NetCDF: Access failure\" xarrar >= 0.20\n",
+    "    # \"Authorization failure\" xarray < 0.17\n",
+    "    assert (\"NetCDF: Access failure\" in str(exc) or \"Authorization failure\" in str(exc))\n",
     "except HTTPError as exc: # xarray >= 0.17\n",
     "    # note: raised error is 500 with 'message' Unauthorized instead of directly raising HTTPUnauthorized\n",
     "    assert \"401 Unauthorized\" in str(exc)\n",
@@ -1296,7 +1298,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1310,7 +1312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix the following Jenkins error with new Jupyter env from PR https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/94:

```
  _____ pavics-sdi-master/docs/source/notebooks/pavics_thredds.ipynb::Cell 2 _____
  Notebook cell execution failed
  Cell 2: Cell execution caused an exception

  Input:
  from webob.exc import HTTPError

  SECURED_URL = f"{THREDDS_URL}/dodsC/birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc"
  try:
      ds = xr.open_dataset(SECURED_URL, decode_cf=False)
  # depending on 'xarray' version, differnt errors are raised when failing authentication according on how they handle it
  except OSError as exc:  # xarray < 0.17
      assert "Authorization failure" in str(exc)
  except HTTPError as exc: # xarray >= 0.17
      # note: raised error is 500 with 'message' Unauthorized instead of directly raising HTTPUnauthorized
      assert "401 Unauthorized" in str(exc)
  else:
      raise RuntimeError("Expected unauthorized response, but dataset open operation did not raise!")
  print("Unauthorized was raised as expected.")

  Traceback:

  ---------------------------------------------------------------------------
  KeyError                                  Traceback (most recent call last)
  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/file_manager.py in _acquire_with_cache_info(self, needs_lock)
      198             try:
  --> 199                 file = self._cache[self._key]
      200             except KeyError:

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/lru_cache.py in __getitem__(self, key)
       52         with self._lock:
  ---> 53             value = self._cache[key]
       54             self._cache.move_to_end(key)

  KeyError: [<class 'netCDF4._netCDF4.Dataset'>, ('https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc',), 'r', (('clobber', True), ('diskless', False), ('format', 'NETCDF4'), ('persist', False))]

  During handling of the above exception, another exception occurred:

  OSError                                   Traceback (most recent call last)
  /tmp/ipykernel_529/972745888.py in <module>
        4 try:
  ----> 5     ds = xr.open_dataset(SECURED_URL, decode_cf=False)
        6 # depending on 'xarray' version, differnt errors are raised when failing authentication according on how they handle it

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/api.py in open_dataset(filename_or_obj, engine, chunks, cache, decode_cf, mask_and_scale, decode_times, decode_timedelta, use_cftime, concat_characters, decode_coords, drop_variables, backend_kwargs, *args, **kwargs)
      498         **decoders,
  --> 499         **kwargs,
      500     )

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/netCDF4_.py in open_dataset(self, filename_or_obj, mask_and_scale, decode_times, concat_characters, decode_coords, drop_variables, use_cftime, decode_timedelta, group, mode, format, clobber, diskless, persist, lock, autoclose)
      558             lock=lock,
  --> 559             autoclose=autoclose,
      560         )

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/netCDF4_.py in open(cls, filename, mode, format, group, clobber, diskless, persist, lock, lock_maker, autoclose)
      378         )
  --> 379         return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)
      380

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/netCDF4_.py in __init__(self, manager, group, mode, lock, autoclose)
      326         self._mode = mode
  --> 327         self.format = self.ds.data_model
      328         self._filename = self.ds.filepath()

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/netCDF4_.py in ds(self)
      387     def ds(self):
  --> 388         return self._acquire()
      389

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/netCDF4_.py in _acquire(self, needs_lock)
      381     def _acquire(self, needs_lock=True):
  --> 382         with self._manager.acquire_context(needs_lock) as root:
      383             ds = _nc4_require_group(root, self._group, self._mode)

  /opt/conda/envs/birdy/lib/python3.7/contextlib.py in __enter__(self)
      111         try:
  --> 112             return next(self.gen)
      113         except StopIteration:

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/file_manager.py in acquire_context(self, needs_lock)
      186         """Context manager for acquiring a file."""
  --> 187         file, cached = self._acquire_with_cache_info(needs_lock)
      188         try:

  /opt/conda/envs/birdy/lib/python3.7/site-packages/xarray/backends/file_manager.py in _acquire_with_cache_info(self, needs_lock)
      204                     kwargs["mode"] = self._mode
  --> 205                 file = self._opener(*self._args, **kwargs)
      206                 if self._mode == "w":

  src/netCDF4/_netCDF4.pyx in netCDF4._netCDF4.Dataset.__init__()

  src/netCDF4/_netCDF4.pyx in netCDF4._netCDF4._ensure_nc_success()

  OSError: [Errno -77] NetCDF: Access failure: b'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/secure/tasmax_Amon_MPI-ESM-MR_rcp45_r2i1p1_200601-200612.nc'

  During handling of the above exception, another exception occurred:

  AssertionError                            Traceback (most recent call last)
  /tmp/ipykernel_529/972745888.py in <module>
        6 # depending on 'xarray' version, differnt errors are raised when failing authentication according on how they handle it
        7 except OSError as exc:  # xarray < 0.17
  ----> 8     assert "Authorization failure" in str(exc)
        9 except HTTPError as exc: # xarray >= 0.17
       10     # note: raised error is 500 with 'message' Unauthorized instead of directly raising HTTPUnauthorized

  AssertionError:
```