### PR TITLE
Use catalog from prod and fix output url format change from Finch 0.8.0

### DIFF
--- a/docs/source/notebooks/climex.ipynb
+++ b/docs/source/notebooks/climex.ipynb
@@ -106,7 +106,7 @@
     "import xclim\n",
     "from dask.diagnostics import ProgressBar\n",
     "\n",
-    "cat = intake.open_esm_datastore(\"https://pavics.ouranos.ca/catalog/climex.json\")\n",
+    "cat = intake.open_esm_datastore(\"https://pavics.ouranos.ca/catalog/climex.json\")  # TEST_USE_PROD_DATA\n",
     "cat.df.head()"
    ]
   },
@@ -2950,7 +2950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/subset-user-input.ipynb
+++ b/docs/source/notebooks/subset-user-input.ipynb
@@ -1347,6 +1347,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# wait for process to complete before running this cell (the process is async)\n",
     "tasmin_subset = result_tasmin.get().output\n",
     "tasmin_subset"
@@ -1387,6 +1389,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# wait for process to complete before running this cell (the process is async)\n",
     "tasmax_subset = result_tasmax.get().output\n",
     "tasmax_subset"
@@ -1659,7 +1663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
`climex.ipynb` and `forecasts.ipynb` use the catalog that are not deployed on test servers.  We need to force the catalog from the production server for these notebooks to pass on test servers.

Finch 0.8.0 from PR https://github.com/bird-house/birdhouse-deploy/pull/231 seems to have changed the output url format, causing the following Jenkins error in `subset-user-input.ipynb`:

```
  ___ pavics-sdi-master/docs/source/notebooks/subset-user-input.ipynb::Cell 15 ___
  Notebook cell execution failed
  Cell 15: Cell outputs differ

  Input:
  # wait for process to complete before running this cell (the process is async)
  tasmin_subset = result_tasmin.get().output
  tasmin_subset

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    "'https://WPS..._v2_sub.ncml'" == "'https://WPS...8fa_sub.ncml'"
    Skipping 40 identical leading characters in diff, use -v to show
    - /nrcan_v2_x9fja8fa_sub.ncml'
    ?           ---------
    + /nrcan_v2_sub.ncml'

  ___ pavics-sdi-master/docs/source/notebooks/subset-user-input.ipynb::Cell 17 ___
  Notebook cell execution failed
  Cell 17: Cell outputs differ

  Input:
  # wait for process to complete before running this cell (the process is async)
  tasmax_subset = result_tasmax.get().output
  tasmax_subset

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    "'https://WPS..._v2_sub.ncml'" == "'https://WPS...a44_sub.ncml'"
    Skipping 40 identical leading characters in diff, use -v to show
    - /nrcan_v2_qbj57a44_sub.ncml'
    ?           ---------
    + /nrcan_v2_sub.ncml'
```