### PR TITLE
output job logs in assert message for test debuging

### DIFF
--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -1171,11 +1171,10 @@
     "logs = resp.json()\n",
     "\n",
     "log_lines = \"\\n\".join(logs)\n",
-    "print(f\"Job logs retrieved from [{path}]:\\n\\n{log_lines}\")\n",
-    "\n",
     "assert len(logs) > 1\n",
-    "assert status == \"succeeded\", f\"Job execution was not successful. Status: [{status}]\"\n",
-    "assert \"100%\" in logs[-1] and \"succeeded\" in logs[-1], f\"Log entry: [{logs[-1]}]\"\n"
+    "assert status == \"succeeded\", f\"Job execution was not successful. Status: [{status}]\\nFull Logs:\\n\\n{log_lines}\"\n",
+    "assert \"100%\" in logs[-1] and \"succeeded\" in logs[-1], f\"Log entry: [{logs[-1]}]\\nFull Logs:\\n\\n{log_lines}\"\n",
+    "print(f\"Job logs retrieved from [{path}]:\\n\\n{log_lines}\")\n"
    ]
   },
   {


### PR DESCRIPTION
Output Weaver's failing Job logs directly in the error message to help debugging the cause.
When running on Jenkins, collected artifacts actually contain the *expected* notebook outputs rather than *obtained* outputs... therefore it is impossible to debug the cause accordingly. 
