### PR TITLE
notebooks: allow to test GeoServer on new production server and fix old .ncml path

### DIFF
--- a/docs/source/notebooks/WFS_example.ipynb
+++ b/docs/source/notebooks/WFS_example.ipynb
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start by making a connection to the PAVICS instance we have locally on our server, `Boreas`. Using WFS, we can very quickly see the contents, which are the layers and the workspaces they're located with (ie: TravisTest, scratchTJS). These layer names act as dictionaries for "
+    "We start by making a connection to the PAVICS instance we have locally on our server. Using WFS, we can very quickly see the contents, which are the layers and the workspaces they're located with (ie: TravisTest, scratchTJS). These layer names act as dictionaries for "
    ]
   },
   {
@@ -73,7 +73,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "wfs_url = 'http://boreas.ouranos.ca/geoserver/wfs'\n",
+    "wfs_url = 'https://pavics.ouranos.ca/geoserver/wfs'  # TEST_USE_PROD_DATA\n",
     "\n",
     "# Connect to GeoServer WFS service. \n",
     "wfs = WebFeatureService(wfs_url, version='2.0.0')\n",
@@ -162,9 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "Once the geoJSON file is downloaded, we can either open it with a GIS application or we can read the features using geopandas."
    ]
@@ -212,7 +210,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -226,9 +224,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/source/notebooks/regridding.ipynb
+++ b/docs/source/notebooks/regridding.ipynb
@@ -2739,7 +2739,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "wfs_url = 'http://boreas.ouranos.ca/geoserver/wfs'\n",
+    "wfs_url = 'https://pavics.ouranos.ca/geoserver/wfs'  # TEST_USE_PROD_DATA\n",
     "# Connect to GeoServer WFS service.\n",
     "wfs = WebFeatureService(wfs_url, version='2.0.0')\n",
     "\n",
@@ -3871,7 +3871,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -3885,7 +3885,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/regridding.ipynb
+++ b/docs/source/notebooks/regridding.ipynb
@@ -998,7 +998,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "url_obs = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/nrcan/nrcan_canada_daily_v2/nrcan_canada_daily_V2-allvars-agg.ncml\"\n",
+    "url_obs = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml\"\n",
     "\n",
     "# For this example, we're not interested in the observation data, only its underlying grid, so we'll select a single time step. \n",
     "ds_obs = xr.open_dataset(url_obs).sel(time='1993-05-20')\n",


### PR DESCRIPTION
Switch from `boreas.ouranos.ca` to `pavics.ouranos.ca` will allow us to
conditionally regex replace `pavics.ouranos.ca` to the server under test
so we can actually test the Geoserver on that new server.

Everywhere under this pavics-sdi repo, we use `pavics.ouranos.ca`.  This
is the only locations that hardcode `boreas.ouranos.ca` because
geoserver data are not replicated to standard test servers so hardcoding
it this way will use the data from the production server.

This patch achieve the same "data from prod" but also allow override if
we need to actually test the future production server.

Related to https://github.com/Ouranosinc/pavics-sdi/issues/183 and https://github.com/Ouranosinc/PAVICS-e2e-workflow-tests/pull/104.

Also fix old `nrcan_v2.ncml` path in `regridding.ipynb`.