### PR TITLE
add missing `geoseries_to_netcdf` from `finch` provider in weaver notebook

### DIFF
--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -529,6 +529,7 @@
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/frost_free_season_length\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/frost_free_season_start\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/frost_season_length\n",
+      " - https://pavics.ouranos.ca/weaver/providers/finch/processes/geoseries_to_netcdf\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/growing_degree_days\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/growing_season_end\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/growing_season_length\n",


### PR DESCRIPTION
Another new process I missed in #255 

I ran the notebook against the current birdhouse-deploy master. 
Should be the last diff.