### PR TITLE
climex.ipynb: fix Jenkins failure due to climex link on wrong server

### DIFF
--- a/docs/source/notebooks/climex.ipynb
+++ b/docs/source/notebooks/climex.ipynb
@@ -112,9 +112,11 @@
     "from IPython.display import HTML, Markdown\n",
     "from xclim import ensembles as xens\n",
     "\n",
-    "cat = intake.open_esm_datastore(\n",
-    "    \"https://pavics.ouranos.ca/catalog/climex.json\"\n",
-    ")  # TEST_USE_PROD_DATA\n",
+    "# fmt: off\n",
+    "climex = \"https://pavics.ouranos.ca/catalog/climex.json\"  # TEST_USE_PROD_DATA\n",
+    "cat = intake.open_esm_datastore(climex)\n",
+    "# fmt: on\n",
+    "\n",
     "cat.df.head()"
    ]
   },


### PR DESCRIPTION
Should have used the climex link on PAVICS prod server instead of the test server.

`TEST_USE_PROD_DATA` should be on the same line as "pavics.ouranos.ca" to avoid it being replaced by the test server during Jenkins run.

The precommit autoformatter should not break that line.

See previous fix that was lost, not sure why
https://github.com/Ouranosinc/pavics-sdi/commit/75652fbe9751bc1f2b85109daf44402533639e8b (PR https://github.com/Ouranosinc/pavics-sdi/pull/267)

Jenkins failure found in PR https://github.com/bird-house/birdhouse-deploy/pull/280#issuecomment-1404323983:
```
10:36:34  _________ pavics-sdi-master/docs/source/notebooks/climex.ipynb::Cell 0 _________
10:36:34  Notebook cell execution failed
10:36:34  Cell 0: Cell execution caused an exception
10:36:34  
10:36:34  Input:
10:36:34  import shutil
10:36:34  
10:36:34  import intake
10:36:34  import xarray as xr
10:36:34  import xclim
10:36:34  from clisops.core.subset import subset_gridpoint
10:36:34  from dask.diagnostics import ProgressBar
10:36:34  from dask.distributed import Client, LocalCluster
10:36:34  from IPython.display import HTML, Markdown
10:36:34  from xclim import ensembles as xens
10:36:34  
10:36:34  cat = intake.open_esm_datastore(
10:36:34      "https://host-140-154.rdext.crim.ca/catalog/climex.json"
10:36:34  )  # TEST_USE_PROD_DATA
10:36:34  cat.df.head()
10:36:34  
10:36:34  Traceback:
10:36:34  
10:36:34  ---------------------------------------------------------------------------
10:36:34  JSONDecodeError                           Traceback (most recent call last)
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/site-packages/requests/models.py:971, in Response.json(self, **kwargs)
10:36:34      970 try:
10:36:34  --> 971     return complexjson.loads(self.text, **kwargs)
10:36:34      972 except JSONDecodeError as e:
10:36:34      973     # Catch JSON-related errors and raise as requests.JSONDecodeError
10:36:34      974     # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/json/__init__.py:357, in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
10:36:34      354 if (cls is None and object_hook is None and
10:36:34      355         parse_int is None and parse_float is None and
10:36:34      356         parse_constant is None and object_pairs_hook is None and not kw):
10:36:34  --> 357     return _default_decoder.decode(s)
10:36:34      358 if cls is None:
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/json/decoder.py:337, in JSONDecoder.decode(self, s, _w)
10:36:34      333 """Return the Python representation of ``s`` (a ``str`` instance
10:36:34      334 containing a JSON document).
10:36:34      335 
10:36:34      336 """
10:36:34  --> 337 obj, end = self.raw_decode(s, idx=_w(s, 0).end())
10:36:34      338 end = _w(s, end).end()
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/json/decoder.py:355, in JSONDecoder.raw_decode(self, s, idx)
10:36:34      354 except StopIteration as err:
10:36:34  --> 355     raise JSONDecodeError("Expecting value", s, err.value) from None
10:36:34      356 return obj, end
10:36:34  
10:36:34  JSONDecodeError: Expecting value: line 4 column 1 (char 3)
10:36:34  
10:36:34  During handling of the above exception, another exception occurred:
10:36:34  
10:36:34  JSONDecodeError                           Traceback (most recent call last)
10:36:34  Cell In [1], line 12
10:36:34        9 from IPython.display import HTML, Markdown
10:36:34       10 from xclim import ensembles as xens
10:36:34  ---> 12 cat = intake.open_esm_datastore(
10:36:34       13     "https://host-140-154.rdext.crim.ca/catalog/climex.json"
10:36:34       14 )  # TEST_USE_PROD_DATA
10:36:34       15 cat.df.head()
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/site-packages/intake_esm/core.py:83, in esm_datastore.__init__(self, esmcol_obj, esmcol_data, progressbar, sep, csv_kwargs, **kwargs)
10:36:34       81 super(esm_datastore, self).__init__(**kwargs)
10:36:34       82 if isinstance(esmcol_obj, (str, pathlib.PurePath)):
10:36:34  ---> 83     self.esmcol_data, self.esmcol_path = _fetch_and_parse_json(esmcol_obj)
10:36:34       84     self._df, self.catalog_file = _fetch_catalog(self.esmcol_data, esmcol_obj, csv_kwargs)
10:36:34       86 elif isinstance(esmcol_obj, pd.DataFrame):
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/site-packages/intake_esm/utils.py:59, in _fetch_and_parse_json(input_path)
10:36:34       56             data = json.load(filein)
10:36:34       58 except Exception as exc:
10:36:34  ---> 59     raise exc
10:36:34       61 return data, input_path
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/site-packages/intake_esm/utils.py:52, in _fetch_and_parse_json(input_path)
10:36:34       50 if _is_valid_url(input_path):
10:36:34       51     resp = requests.get(input_path)
10:36:34  ---> 52     data = resp.json()
10:36:34       53 else:
10:36:34       54     input_path = Path(input_path).absolute().as_posix()
10:36:34  
10:36:34  File /opt/conda/envs/birdy/lib/python3.8/site-packages/requests/models.py:975, in Response.json(self, **kwargs)
10:36:34      971     return complexjson.loads(self.text, **kwargs)
10:36:34      972 except JSONDecodeError as e:
10:36:34      973     # Catch JSON-related errors and raise as requests.JSONDecodeError
10:36:34      974     # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
10:36:34  --> 975     raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
10:36:34  
10:36:34  JSONDecodeError: Expecting value: line 4 column 1 (char 3)
```