### PR TITLE
esgf-dap.ipynb: output change due to content change on server (CanESM5-1 added to query result)

### DIFF
--- a/docs/source/notebooks/esgf-dap.ipynb
+++ b/docs/source/notebooks/esgf-dap.ipynb
@@ -14,13 +14,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-05-02T01:07:17.025830Z",
+     "iopub.status.busy": "2023-05-02T01:07:17.025420Z",
+     "iopub.status.idle": "2023-05-02T01:07:17.773387Z",
+     "shell.execute_reply": "2023-05-02T01:07:17.771946Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of results:  10084\n",
+      "Number of results:  10114\n",
       "Variables related to humidity: \n"
      ]
     },
@@ -36,13 +43,13 @@
        " 'tnhusa': 174,\n",
        " 'tnhus': 76,\n",
        " 'hussLut': 34,\n",
-       " 'huss': 1912,\n",
+       " 'huss': 1918,\n",
        " 'hus850': 164,\n",
-       " 'hus': 2288,\n",
-       " 'hursmin': 639,\n",
-       " 'hursmax': 624,\n",
-       " 'hurs': 1912,\n",
-       " 'hur': 1546}"
+       " 'hus': 2294,\n",
+       " 'hursmin': 642,\n",
+       " 'hursmax': 627,\n",
+       " 'hurs': 1918,\n",
+       " 'hur': 1552}"
       ]
      },
      "execution_count": 1,
@@ -74,7 +81,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-05-02T01:07:17.835479Z",
+     "iopub.status.busy": "2023-05-02T01:07:17.834654Z",
+     "iopub.status.idle": "2023-05-02T01:07:17.847182Z",
+     "shell.execute_reply": "2023-05-02T01:07:17.846378Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -112,6 +126,7 @@
        " 'EC-Earth3': 817,\n",
        " 'E3SM-1-1': 22,\n",
        " 'CanESM5-CanOE': 24,\n",
+       " 'CanESM5-1': 30,\n",
        " 'CanESM5': 1033,\n",
        " 'CNRM-ESM2-1': 108,\n",
        " 'CNRM-CM6-1-HR': 19,\n",
@@ -143,7 +158,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-05-02T01:07:17.856171Z",
+     "iopub.status.busy": "2023-05-02T01:07:17.854928Z",
+     "iopub.status.idle": "2023-05-02T01:07:18.973806Z",
+     "shell.execute_reply": "2023-05-02T01:07:18.972798Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -166,7 +188,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-05-02T01:07:18.978688Z",
+     "iopub.status.busy": "2023-05-02T01:07:18.977733Z",
+     "iopub.status.idle": "2023-05-02T01:08:04.020834Z",
+     "shell.execute_reply": "2023-05-02T01:08:04.019590Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -190,7 +219,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-05-02T01:08:04.026013Z",
+     "iopub.status.busy": "2023-05-02T01:08:04.025458Z",
+     "iopub.status.idle": "2023-05-02T01:08:05.575807Z",
+     "shell.execute_reply": "2023-05-02T01:08:05.574541Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -217,7 +253,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-05-02T01:08:05.584670Z",
+     "iopub.status.busy": "2023-05-02T01:08:05.583735Z",
+     "iopub.status.idle": "2023-05-02T01:08:07.825762Z",
+     "shell.execute_reply": "2023-05-02T01:08:07.822731Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -600,16 +643,16 @@
        "    version:                         v20190429\n",
        "    license:                         CMIP6 model data produced by The Governm...\n",
        "    cmor_version:                    3.5.0\n",
-       "    DODS_EXTRA.Unlimited_Dimension:  time</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-661f371f-ca31-4879-a8c7-2e126174ae52' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-661f371f-ca31-4879-a8c7-2e126174ae52' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1032</li><li><span>bnds</span>: 2</li><li><span class='xr-has-index'>plev</span>: 19</li><li><span class='xr-has-index'>lat</span>: 64</li><li><span class='xr-has-index'>lon</span>: 128</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-930520ca-7bc4-4428-b6aa-360b39ec36d1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-930520ca-7bc4-4428-b6aa-360b39ec36d1' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2015-01-16 12:00:00 ... 2100-12-...</div><input id='attrs-44ba25c1-f730-4606-81ca-5c9c9120cf6e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-44ba25c1-f730-4606-81ca-5c9c9120cf6e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa621de4-a480-4c32-a658-50c9026cd6cb' class='xr-var-data-in' type='checkbox'><label for='data-fa621de4-a480-4c32-a658-50c9026cd6cb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>axis :</span></dt><dd>T</dd><dt><span>long_name :</span></dt><dd>time</dd><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>_ChunkSizes :</span></dt><dd>1</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeNoLeap(2015, 1, 16, 12, 0, 0, 0, has_year_zero=True),\n",
+       "    DODS_EXTRA.Unlimited_Dimension:  time</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2f009abc-7f76-4a4a-8f71-5cb06fc09f42' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2f009abc-7f76-4a4a-8f71-5cb06fc09f42' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 1032</li><li><span>bnds</span>: 2</li><li><span class='xr-has-index'>plev</span>: 19</li><li><span class='xr-has-index'>lat</span>: 64</li><li><span class='xr-has-index'>lon</span>: 128</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-7d141d1a-1a68-4c6d-8765-80d4c070e0f2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7d141d1a-1a68-4c6d-8765-80d4c070e0f2' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2015-01-16 12:00:00 ... 2100-12-...</div><input id='attrs-233e39a5-4eda-4bf5-b2da-0befb0144673' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-233e39a5-4eda-4bf5-b2da-0befb0144673' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ea4e11a0-c2cc-4361-a811-6246668718a7' class='xr-var-data-in' type='checkbox'><label for='data-ea4e11a0-c2cc-4361-a811-6246668718a7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>time_bnds</dd><dt><span>axis :</span></dt><dd>T</dd><dt><span>long_name :</span></dt><dd>time</dd><dt><span>standard_name :</span></dt><dd>time</dd><dt><span>_ChunkSizes :</span></dt><dd>1</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeNoLeap(2015, 1, 16, 12, 0, 0, 0, has_year_zero=True),\n",
        "       cftime.DatetimeNoLeap(2015, 2, 15, 0, 0, 0, 0, has_year_zero=True),\n",
        "       cftime.DatetimeNoLeap(2015, 3, 16, 12, 0, 0, 0, has_year_zero=True),\n",
        "       ...,\n",
        "       cftime.DatetimeNoLeap(2100, 10, 16, 12, 0, 0, 0, has_year_zero=True),\n",
        "       cftime.DatetimeNoLeap(2100, 11, 16, 0, 0, 0, 0, has_year_zero=True),\n",
        "       cftime.DatetimeNoLeap(2100, 12, 16, 12, 0, 0, 0, has_year_zero=True)],\n",
-       "      dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>plev</span></div><div class='xr-var-dims'>(plev)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1e+05 9.25e+04 ... 500.0 100.0</div><input id='attrs-da5134bd-95b7-4a6b-a351-5c0c504d307c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-da5134bd-95b7-4a6b-a351-5c0c504d307c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a3823b35-2151-41ba-a7d0-865c3ae6e3ba' class='xr-var-data-in' type='checkbox'><label for='data-a3823b35-2151-41ba-a7d0-865c3ae6e3ba' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>Pa</dd><dt><span>axis :</span></dt><dd>Z</dd><dt><span>positive :</span></dt><dd>down</dd><dt><span>long_name :</span></dt><dd>pressure</dd><dt><span>standard_name :</span></dt><dd>air_pressure</dd></dl></div><div class='xr-var-data'><pre>array([100000.,  92500.,  85000.,  70000.,  60000.,  50000.,  40000.,  30000.,\n",
+       "      dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>plev</span></div><div class='xr-var-dims'>(plev)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1e+05 9.25e+04 ... 500.0 100.0</div><input id='attrs-1b52a7a2-dda6-46df-a810-2d82685a6e9b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1b52a7a2-dda6-46df-a810-2d82685a6e9b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-08688ab3-3187-4044-9b68-e04d89f0e583' class='xr-var-data-in' type='checkbox'><label for='data-08688ab3-3187-4044-9b68-e04d89f0e583' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>units :</span></dt><dd>Pa</dd><dt><span>axis :</span></dt><dd>Z</dd><dt><span>positive :</span></dt><dd>down</dd><dt><span>long_name :</span></dt><dd>pressure</dd><dt><span>standard_name :</span></dt><dd>air_pressure</dd></dl></div><div class='xr-var-data'><pre>array([100000.,  92500.,  85000.,  70000.,  60000.,  50000.,  40000.,  30000.,\n",
        "        25000.,  20000.,  15000.,  10000.,   7000.,   5000.,   3000.,   2000.,\n",
-       "         1000.,    500.,    100.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-87.86 -85.1 -82.31 ... 85.1 87.86</div><input id='attrs-cd947ec3-fd7c-463d-bdd9-79032efbaa98' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd947ec3-fd7c-463d-bdd9-79032efbaa98' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-46610d93-5754-4eaf-a49e-f1c3fe32918d' class='xr-var-data-in' type='checkbox'><label for='data-46610d93-5754-4eaf-a49e-f1c3fe32918d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>lat_bnds</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([-87.863799, -85.096527, -82.312913, -79.525607, -76.7369  , -73.947515,\n",
+       "         1000.,    500.,    100.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-87.86 -85.1 -82.31 ... 85.1 87.86</div><input id='attrs-5ce01d9d-6148-43e9-ba61-a002f332fe72' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5ce01d9d-6148-43e9-ba61-a002f332fe72' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5deda8cb-1803-4322-8799-176795433489' class='xr-var-data-in' type='checkbox'><label for='data-5deda8cb-1803-4322-8799-176795433489' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>lat_bnds</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>axis :</span></dt><dd>Y</dd><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([-87.863799, -85.096527, -82.312913, -79.525607, -76.7369  , -73.947515,\n",
        "       -71.157752, -68.367756, -65.577607, -62.787352, -59.99702 , -57.206632,\n",
        "       -54.4162  , -51.625734, -48.835241, -46.044727, -43.254195, -40.463648,\n",
        "       -37.67309 , -34.882521, -32.091944, -29.30136 , -26.510769, -23.720174,\n",
@@ -619,7 +662,7 @@
        "        29.30136 ,  32.091944,  34.882521,  37.67309 ,  40.463648,  43.254195,\n",
        "        46.044727,  48.835241,  51.625734,  54.4162  ,  57.206632,  59.99702 ,\n",
        "        62.787352,  65.577607,  68.367756,  71.157752,  73.947515,  76.7369  ,\n",
-       "        79.525607,  82.312913,  85.096527,  87.863799])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.0 2.812 5.625 ... 354.4 357.2</div><input id='attrs-b6699041-20cd-46af-ad1c-2ceb688d3769' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b6699041-20cd-46af-ad1c-2ceb688d3769' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-77ebc3c3-ca12-4376-aef1-9f4579a2dcd0' class='xr-var-data-in' type='checkbox'><label for='data-77ebc3c3-ca12-4376-aef1-9f4579a2dcd0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>lon_bnds</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([  0.    ,   2.8125,   5.625 ,   8.4375,  11.25  ,  14.0625,  16.875 ,\n",
+       "        79.525607,  82.312913,  85.096527,  87.863799])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.0 2.812 5.625 ... 354.4 357.2</div><input id='attrs-98eb1a56-d057-463b-90be-0a2bb2bccc38' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-98eb1a56-d057-463b-90be-0a2bb2bccc38' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c8ffb325-f82a-45c5-829c-37eedff7307f' class='xr-var-data-in' type='checkbox'><label for='data-c8ffb325-f82a-45c5-829c-37eedff7307f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>bounds :</span></dt><dd>lon_bnds</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>axis :</span></dt><dd>X</dd><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([  0.    ,   2.8125,   5.625 ,   8.4375,  11.25  ,  14.0625,  16.875 ,\n",
        "        19.6875,  22.5   ,  25.3125,  28.125 ,  30.9375,  33.75  ,  36.5625,\n",
        "        39.375 ,  42.1875,  45.    ,  47.8125,  50.625 ,  53.4375,  56.25  ,\n",
        "        59.0625,  61.875 ,  64.6875,  67.5   ,  70.3125,  73.125 ,  75.9375,\n",
@@ -637,7 +680,7 @@
        "       295.3125, 298.125 , 300.9375, 303.75  , 306.5625, 309.375 , 312.1875,\n",
        "       315.    , 317.8125, 320.625 , 323.4375, 326.25  , 329.0625, 331.875 ,\n",
        "       334.6875, 337.5   , 340.3125, 343.125 , 345.9375, 348.75  , 351.5625,\n",
-       "       354.375 , 357.1875])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5c35bffa-261d-4689-90fc-94637eddc110' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5c35bffa-261d-4689-90fc-94637eddc110' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1032, 2), meta=np.ndarray&gt;</div><input id='attrs-82a16335-d041-4af1-a5da-6ee6056ac8e3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-82a16335-d041-4af1-a5da-6ee6056ac8e3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ae4122a2-87fc-4eb5-9a68-9df68d7e1680' class='xr-var-data-in' type='checkbox'><label for='data-ae4122a2-87fc-4eb5-9a68-9df68d7e1680' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_ChunkSizes :</span></dt><dd>[1 2]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       354.375 , 357.1875])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c04ed72c-c542-47d0-af95-0d19a36f38be' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c04ed72c-c542-47d0-af95-0d19a36f38be' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>time_bnds</span></div><div class='xr-var-dims'>(time, bnds)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1032, 2), meta=np.ndarray&gt;</div><input id='attrs-66cdefab-af63-4ab9-bd39-410a3f8ec5d7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-66cdefab-af63-4ab9-bd39-410a3f8ec5d7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-943d903e-6d22-4c2e-867b-9e04fab81f89' class='xr-var-data-in' type='checkbox'><label for='data-943d903e-6d22-4c2e-867b-9e04fab81f89' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_ChunkSizes :</span></dt><dd>[1 2]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -692,7 +735,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat_bnds</span></div><div class='xr-var-dims'>(lat, bnds)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(64, 2), meta=np.ndarray&gt;</div><input id='attrs-5ba78d01-8442-4fe1-ba68-c045de90f278' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5ba78d01-8442-4fe1-ba68-c045de90f278' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0d2bd70f-fa9a-43d3-b73c-84032012b560' class='xr-var-data-in' type='checkbox'><label for='data-0d2bd70f-fa9a-43d3-b73c-84032012b560' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_ChunkSizes :</span></dt><dd>[64  2]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lat_bnds</span></div><div class='xr-var-dims'>(lat, bnds)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(64, 2), meta=np.ndarray&gt;</div><input id='attrs-645cf6b9-6067-482f-a60f-5cd6998a7c13' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-645cf6b9-6067-482f-a60f-5cd6998a7c13' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-577f2b54-21c1-497e-ac0e-08aff1d5f566' class='xr-var-data-in' type='checkbox'><label for='data-577f2b54-21c1-497e-ac0e-08aff1d5f566' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_ChunkSizes :</span></dt><dd>[64  2]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -747,7 +790,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon_bnds</span></div><div class='xr-var-dims'>(lon, bnds)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(128, 2), meta=np.ndarray&gt;</div><input id='attrs-cd09c400-e320-45fc-baaf-ebf7f353acd6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cd09c400-e320-45fc-baaf-ebf7f353acd6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c6de931c-3d5c-49c3-ab9b-c2b30bcbaf12' class='xr-var-data-in' type='checkbox'><label for='data-c6de931c-3d5c-49c3-ab9b-c2b30bcbaf12' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_ChunkSizes :</span></dt><dd>[128   2]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lon_bnds</span></div><div class='xr-var-dims'>(lon, bnds)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(128, 2), meta=np.ndarray&gt;</div><input id='attrs-60594da9-2983-4f83-badb-cf2ce4be3dcf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-60594da9-2983-4f83-badb-cf2ce4be3dcf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0ff3835-a664-44f9-85cd-e1755a0e5f9d' class='xr-var-data-in' type='checkbox'><label for='data-e0ff3835-a664-44f9-85cd-e1755a0e5f9d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_ChunkSizes :</span></dt><dd>[128   2]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -802,7 +845,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>hus</span></div><div class='xr-var-dims'>(time, plev, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1032, 19, 64, 128), meta=np.ndarray&gt;</div><input id='attrs-6fd315ea-0cd1-4148-95f2-9ab566e18f46' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6fd315ea-0cd1-4148-95f2-9ab566e18f46' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-00fd5803-ba4c-4e1b-b7ec-ea8dca349a87' class='xr-var-data-in' type='checkbox'><label for='data-00fd5803-ba4c-4e1b-b7ec-ea8dca349a87' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>specific_humidity</dd><dt><span>long_name :</span></dt><dd>Specific Humidity</dd><dt><span>comment :</span></dt><dd>Specific humidity is the mass fraction of water vapor in (moist) air.</dd><dt><span>units :</span></dt><dd>1</dd><dt><span>original_name :</span></dt><dd>SHUM</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>cell_measures :</span></dt><dd>area: areacella</dd><dt><span>history :</span></dt><dd>2019-09-25T23:36:52Z altered by CMOR: Reordered dimensions, original order: lat lon plev time. 2019-09-25T23:36:52Z altered by CMOR: replaced missing value flag (1e+38) and corresponding data with standard missing value (1e+20).</dd><dt><span>_ChunkSizes :</span></dt><dd>[  1  19  64 128]</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>hus</span></div><div class='xr-var-dims'>(time, plev, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1032, 19, 64, 128), meta=np.ndarray&gt;</div><input id='attrs-ae9688df-dbab-485c-a7c8-aa8dfe09e9f4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae9688df-dbab-485c-a7c8-aa8dfe09e9f4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b1fa53db-050b-4112-bfa7-5fa0bc24c6b0' class='xr-var-data-in' type='checkbox'><label for='data-b1fa53db-050b-4112-bfa7-5fa0bc24c6b0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>specific_humidity</dd><dt><span>long_name :</span></dt><dd>Specific Humidity</dd><dt><span>comment :</span></dt><dd>Specific humidity is the mass fraction of water vapor in (moist) air.</dd><dt><span>units :</span></dt><dd>1</dd><dt><span>original_name :</span></dt><dd>SHUM</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>cell_measures :</span></dt><dd>area: areacella</dd><dt><span>history :</span></dt><dd>2019-09-25T23:36:52Z altered by CMOR: Reordered dimensions, original order: lat lon plev time. 2019-09-25T23:36:52Z altered by CMOR: replaced missing value flag (1e+38) and corresponding data with standard missing value (1e+20).</dd><dt><span>_ChunkSizes :</span></dt><dd>[  1  19  64 128]</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -896,7 +939,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-e5335c29-4958-4a22-9258-d27203c5c424' class='xr-section-summary-in' type='checkbox'  ><label for='section-e5335c29-4958-4a22-9258-d27203c5c424' class='xr-section-summary' >Attributes: <span>(54)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>CCCma_model_hash :</span></dt><dd>fc4bb7db954c862d023b546e19aec6c588bc0552</dd><dt><span>CCCma_parent_runid :</span></dt><dd>p2-his14</dd><dt><span>CCCma_pycmor_hash :</span></dt><dd>26c970628162d607fffd14254956ebc6dd3b6f49</dd><dt><span>CCCma_runid :</span></dt><dd>p2-s4514</dd><dt><span>Conventions :</span></dt><dd>CF-1.7 CMIP-6.2</dd><dt><span>YMDH_branch_time_in_child :</span></dt><dd>2015:01:01:00</dd><dt><span>YMDH_branch_time_in_parent :</span></dt><dd>2015:01:01:00</dd><dt><span>activity_id :</span></dt><dd>ScenarioMIP</dd><dt><span>branch_method :</span></dt><dd>Spin-up documentation</dd><dt><span>branch_time_in_child :</span></dt><dd>60225.0</dd><dt><span>branch_time_in_parent :</span></dt><dd>60225.0</dd><dt><span>contact :</span></dt><dd>ec.cccma.info-info.ccmac.ec@canada.ca</dd><dt><span>creation_date :</span></dt><dd>2019-09-25T23:36:52Z</dd><dt><span>data_specs_version :</span></dt><dd>01.00.30</dd><dt><span>experiment :</span></dt><dd>update of RCP4.5 based on SSP2</dd><dt><span>experiment_id :</span></dt><dd>ssp245</dd><dt><span>external_variables :</span></dt><dd>areacella</dd><dt><span>forcing_index :</span></dt><dd>1</dd><dt><span>frequency :</span></dt><dd>mon</dd><dt><span>further_info_url :</span></dt><dd>https://furtherinfo.es-doc.org/CMIP6.CCCma.CanESM5.ssp245.none.r14i1p2f1</dd><dt><span>grid :</span></dt><dd>T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa</dd><dt><span>grid_label :</span></dt><dd>gn</dd><dt><span>history :</span></dt><dd>2019-09-25T23:36:52Z ;rewrote data to be consistent with ScenarioMIP for variable hus found in table Amon.</dd><dt><span>initialization_index :</span></dt><dd>1</dd><dt><span>institution :</span></dt><dd>Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada, Victoria, BC V8P 5C2, Canada</dd><dt><span>institution_id :</span></dt><dd>CCCma</dd><dt><span>mip_era :</span></dt><dd>CMIP6</dd><dt><span>nominal_resolution :</span></dt><dd>500 km</dd><dt><span>parent_activity_id :</span></dt><dd>CMIP</dd><dt><span>parent_experiment_id :</span></dt><dd>historical</dd><dt><span>parent_mip_era :</span></dt><dd>CMIP6</dd><dt><span>parent_source_id :</span></dt><dd>CanESM5</dd><dt><span>parent_time_units :</span></dt><dd>days since 1850-01-01 0:0:0.0</dd><dt><span>parent_variant_label :</span></dt><dd>r14i1p2f1</dd><dt><span>physics_index :</span></dt><dd>2</dd><dt><span>product :</span></dt><dd>model-output</dd><dt><span>realization_index :</span></dt><dd>14</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>references :</span></dt><dd>Geophysical Model Development Special issue on CanESM5 (https://www.geosci-model-dev.net/special_issue989.html)</dd><dt><span>source :</span></dt><dd>CanESM5 (2019): \n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-2ac9e5b6-492c-45f1-ba1c-ebd2fcb45121' class='xr-section-summary-in' type='checkbox'  ><label for='section-2ac9e5b6-492c-45f1-ba1c-ebd2fcb45121' class='xr-section-summary' >Attributes: <span>(54)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>CCCma_model_hash :</span></dt><dd>fc4bb7db954c862d023b546e19aec6c588bc0552</dd><dt><span>CCCma_parent_runid :</span></dt><dd>p2-his14</dd><dt><span>CCCma_pycmor_hash :</span></dt><dd>26c970628162d607fffd14254956ebc6dd3b6f49</dd><dt><span>CCCma_runid :</span></dt><dd>p2-s4514</dd><dt><span>Conventions :</span></dt><dd>CF-1.7 CMIP-6.2</dd><dt><span>YMDH_branch_time_in_child :</span></dt><dd>2015:01:01:00</dd><dt><span>YMDH_branch_time_in_parent :</span></dt><dd>2015:01:01:00</dd><dt><span>activity_id :</span></dt><dd>ScenarioMIP</dd><dt><span>branch_method :</span></dt><dd>Spin-up documentation</dd><dt><span>branch_time_in_child :</span></dt><dd>60225.0</dd><dt><span>branch_time_in_parent :</span></dt><dd>60225.0</dd><dt><span>contact :</span></dt><dd>ec.cccma.info-info.ccmac.ec@canada.ca</dd><dt><span>creation_date :</span></dt><dd>2019-09-25T23:36:52Z</dd><dt><span>data_specs_version :</span></dt><dd>01.00.30</dd><dt><span>experiment :</span></dt><dd>update of RCP4.5 based on SSP2</dd><dt><span>experiment_id :</span></dt><dd>ssp245</dd><dt><span>external_variables :</span></dt><dd>areacella</dd><dt><span>forcing_index :</span></dt><dd>1</dd><dt><span>frequency :</span></dt><dd>mon</dd><dt><span>further_info_url :</span></dt><dd>https://furtherinfo.es-doc.org/CMIP6.CCCma.CanESM5.ssp245.none.r14i1p2f1</dd><dt><span>grid :</span></dt><dd>T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa</dd><dt><span>grid_label :</span></dt><dd>gn</dd><dt><span>history :</span></dt><dd>2019-09-25T23:36:52Z ;rewrote data to be consistent with ScenarioMIP for variable hus found in table Amon.</dd><dt><span>initialization_index :</span></dt><dd>1</dd><dt><span>institution :</span></dt><dd>Canadian Centre for Climate Modelling and Analysis, Environment and Climate Change Canada, Victoria, BC V8P 5C2, Canada</dd><dt><span>institution_id :</span></dt><dd>CCCma</dd><dt><span>mip_era :</span></dt><dd>CMIP6</dd><dt><span>nominal_resolution :</span></dt><dd>500 km</dd><dt><span>parent_activity_id :</span></dt><dd>CMIP</dd><dt><span>parent_experiment_id :</span></dt><dd>historical</dd><dt><span>parent_mip_era :</span></dt><dd>CMIP6</dd><dt><span>parent_source_id :</span></dt><dd>CanESM5</dd><dt><span>parent_time_units :</span></dt><dd>days since 1850-01-01 0:0:0.0</dd><dt><span>parent_variant_label :</span></dt><dd>r14i1p2f1</dd><dt><span>physics_index :</span></dt><dd>2</dd><dt><span>product :</span></dt><dd>model-output</dd><dt><span>realization_index :</span></dt><dd>14</dd><dt><span>realm :</span></dt><dd>atmos</dd><dt><span>references :</span></dt><dd>Geophysical Model Development Special issue on CanESM5 (https://www.geosci-model-dev.net/special_issue989.html)</dd><dt><span>source :</span></dt><dd>CanESM5 (2019): \n",
        "aerosol: interactive\n",
        "atmos: CanAM5 (T63L49 native atmosphere, T63 Linear Gaussian Grid; 128 x 64 longitude/latitude; 49 levels; top level 1 hPa)\n",
        "atmosChem: specified oxidants for aerosols\n",


### PR DESCRIPTION
Fix this Jenkins failure:
```
  ________ pavics-sdi-master/docs/source/notebooks/esgf-dap.ipynb::Cell 0 ________
  Notebook cell execution failed
  Cell 0: Cell outputs differ

  Input:
  from pyesgf.search import SearchConnection

  # Create a connection for search on ESGF nodes. Note that setting `distrib=True` can lead to weird failures.
  conn = SearchConnection("https://esgf-node.llnl.gov/esg-search/", distrib=False)

  # Launch a search query.
  # Here we're looking for any variable related to humidity within the CMIP6 SSP2-4.5 experiment.
  # Results will be stored in a dictionary with keys defined by the `facets` argument.
  ctx = conn.new_context(
      project="CMIP6",
      experiment_id="ssp245",
      query="humidity",
      facets="variable_id,source_id",
  )

  print("Number of results: ", ctx.hit_count)
  print("Variables related to humidity: ")
  ctx.facet_counts["variable_id"]

  Traceback:
   mismatch 'stdout'

   assert reference_output == test_output failed:

    'Number of re... humidity: \n' == 'Number of re... humidity: \n'
    - Number of results:  10284
    ?                       ^
    + Number of results:  10084
    ?                       ^
      Variables related to humidity:

  ________ pavics-sdi-master/docs/source/notebooks/esgf-dap.ipynb::Cell 1 ________
  Notebook cell execution failed
  Cell 1: Cell outputs differ

  Input:
  # Now let's look for simulations that have the `hurs` variable and pick the first member.
  ctx.constrain(variable_id="hurs", ensemble="r1i1p1f1")
  ctx.facet_counts["source_id"]

  Traceback:
   mismatch 'text/plain'

   assert reference_output == test_output failed:

    "{'UKESM1-0-L...ESS-CM2': 57}" == "{'UKESM1-0-L...ESS-CM2': 57}"
    Skipping 650 identical leading characters in diff, use -v to show

    -  'CanESM5-1': 200,
       'CanESM5': 1033,
       'CNRM-ESM2-1': 108,
       'CNRM-CM6-1-HR': 19,
       'CNRM-CM6-1': 78,
       'CMCC-ESM2': 20,
       'CMCC-CM2-SR5': 18,
       'CIESM': 9,
       'CESM2-WACCM': 168,
       'CESM2': 184,
       'CAS-ESM2-0': 20,
       'CAMS-CSM1-0': 6,
       'BCC-CSM2-MR': 20,
       'AWI-CM-1-1-MR': 19,
       'ACCESS-ESM1-5': 406,
       'ACCESS-CM2': 57}
```