### PR TITLE
Add a docker/dagger-based testing workflow

### DIFF
--- a/.github/workflows/dagger-docker.yml
+++ b/.github/workflows/dagger-docker.yml
@@ -1,0 +1,39 @@
+name: Dagger/Docker Testing Suite
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install pre-commit
+          pre-commit install
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files --show-diff-on-failure
+
+  integration:
+    name: Integration Tests
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Dagger
+        uses: dagger/dagger-for-github@v4
+        with:
+          workdir: ./tests/ci
+          cmds: python test.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
       - id: end-of-file-fixer
         exclude: .ipynb|.po|.xml
       - id: debug-statements
+      - id: check-yaml
+        args: [ '--allow-multiple-documents' ]
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.32.0
+    hooks:
+      - id: yamllint
+        args: [ '--config-file=.yamllint.yaml' ]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
@@ -42,6 +49,11 @@ repos:
       - id: nbstripout
         files: ".ipynb"
         args: [ '--keep-output', '--keep-count' ]
+  - repo: https://github.com/keewis/blackdoc
+    rev: v0.3.8
+    hooks:
+    - id: blackdoc
+      additional_dependencies: ['black==23.3.0']
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+---
+
+rules:
+  document-start: disable
+  line-length:
+    max: 120
+    level: warning
+  truthy: disable

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,4 +11,4 @@ dependencies:
   - pytest
   - sphinx
   - sphinx-intl
-  - sphinx_rtd_theme >=1.0
+  - sphinx-rtd-theme >=1.0

--- a/tests/ci/test.py
+++ b/tests/ci/test.py
@@ -1,0 +1,25 @@
+"""Execute a command."""
+
+import sys
+
+import anyio
+import dagger
+
+
+async def test():
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+        python = (
+            client.container()
+            # pull container
+            .from_("python:3.11-slim-buster")
+            # get Python version
+            .with_exec(["python", "-V"])
+        )
+
+        # execute
+        version = await python.stdout()
+
+    print(f"Hello from Dagger and {version}")
+
+
+anyio.run(test)


### PR DESCRIPTION
## Changes

* Stages a docker-based testing workflow (using [Dagger](https://docs.dagger.io/)) for running integration testing workflows both locally and on CI systems.
* Adds a yaml linting step and a documentation code style checking step to the pre-commit configuration.
* Updates the name of `sphinx-rtd-theme` (previously `sphinx_rtd_theme`).