### PR TITLE
fix weaver outputs with deprecated flyingpigeon removed

### DIFF
--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -22,7 +22,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -151,7 +150,6 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -217,7 +215,6 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -719,7 +716,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -764,7 +760,6 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -1009,7 +1004,6 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -1086,7 +1080,6 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -1177,7 +1170,6 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },
@@ -1278,7 +1270,6 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     },

--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -22,12 +22,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -40,7 +39,7 @@
       "  WEAVER_TEST_WPS_OUTPUTS    https://pavics.ouranos.ca/wpsoutputs\n",
       "  WEAVER_TEST_SSL_VERIFY     True\n",
       "  WEAVER_TEST_FILE           https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/ta_Amon_MRI-CGCM3_decadal1980_r1i1p1_199101-200012.nc\n",
-      "  WEAVER_TEST_KNOWN_BIRDS    ['finch', 'flyingpigeon', 'hummingbird', 'raven']\n",
+      "  WEAVER_TEST_KNOWN_BIRDS    ['finch', 'hummingbird', 'raven']\n",
       "  WEAVER_TEST_REQUEST_XARGS  {'headers': {'Accept': 'application/json', 'Content-Type': 'application/json'}, 'verify': True, 'timeout': 5}\n"
      ]
     }
@@ -119,7 +118,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def json_dump(_json):\n",
@@ -150,12 +151,11 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -168,7 +168,6 @@
       "  \"checked\": false,\n",
       "  \"providers\": [\n",
       "    \"finch\",\n",
-      "    \"flyingpigeon\",\n",
       "    \"hummingbird\",\n",
       "    \"raven\"\n",
       "  ]\n",
@@ -218,12 +217,11 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -232,14 +230,6 @@
      "text": [
       "Listing WPS provider processes converted to OGC-API interface by Weaver:\n",
       "\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/getpoint\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/ncplotly\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/pavicrawler\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/pavicsearch\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/pavicstestdocs\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/pavicsupdate\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/pavicsvalidate\n",
-      " - https://pavics.ouranos.ca/weaver/providers/catalog/processes/period2indices\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/average_polygon\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/base_flow_index\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/biologically_effective_degree_days\n",
@@ -670,19 +660,6 @@
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/wind_vector_from_speed\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/windy_days\n",
       " - https://pavics.ouranos.ca/weaver/providers/finch/processes/winter_storm\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/climatechange_signal\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/plot_map_timemean\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/plot_spaghetti\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/plot_spatial_analog\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/plot_uncertainty\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/plot_uncertaintyrcp\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/pointinspection\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/robustness_statistic\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/spatial_analog\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/subset-wfs-polygon\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/subset_bbox\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/subset_continents\n",
-      " - https://pavics.ouranos.ca/weaver/providers/flyingpigeon/processes/subset_countries\n",
       " - https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/cchecker\n",
       " - https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/cdo_bbox\n",
       " - https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/cdo_copy\n",
@@ -697,36 +674,12 @@
       " - https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/qa_cfchecker\n",
       " - https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/qa_checker\n",
       " - https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/spotchecker\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/climatology_esp\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/climpred_hindcast_verification\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/forecast-floodrisk\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/graph_ensemble_uncertainty\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/graph_fit\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/graph_forecast_uncertainty\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/graph_objective_function_fit\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/graph_single_hydrograph\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/hindcast-evaluation\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/hindcasting\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/hydrobasins-select\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/nalcms-zonal-stats\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/nalcms-zonal-stats-raster\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/objective-function\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/ostrich-gr4j-cemaneige\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/ostrich-hbv-ec\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/ostrich-hmets\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/ostrich-mohyse\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raster-subset\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raven\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raven-gr4j-cemaneige\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raven-hbv-ec\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raven-hmets\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raven-mohyse\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/raven-multi-model\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/realtime-forecast\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/regionalisation\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/shape-properties\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/terrain-analysis\n",
-      " - https://pavics.ouranos.ca/weaver/providers/raven/processes/ts_stats_graph\n",
       " - https://pavics.ouranos.ca/weaver/providers/raven/processes/zonal-stats\n"
      ]
     }
@@ -766,12 +719,11 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -810,14 +762,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1056,14 +1007,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1073,7 +1023,7 @@
       "Submitting process job with:\n",
       "  File:     [https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/ta_Amon_MRI-CGCM3_decadal1980_r1i1p1_199101-200012.nc]\n",
       "  Process:  [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump]\n",
-      "Job Status Location: [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump/jobs/fe9753e3-f0d8-457e-9171-7a0b732fc02c]\n"
+      "Job Status Location: [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump/jobs/7e219013-cbb8-45b2-994f-8c8b33cf6d94]\n"
      ]
     }
    ],
@@ -1134,14 +1084,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1152,7 +1101,7 @@
       "Delay: 5s, Duration: 00:00:00, Status: running\n",
       "Final job status: [failed]\n",
       "Retrying execution... (1/10)\n",
-      "Job Status Location: [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump/jobs/6e23a817-e202-497e-841b-f1d5b2d6eb42] (retry: 1/10)\n",
+      "Job Status Location: [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump/jobs/91b62b44-fb06-4be9-ad2b-43d5265d0048] (retry: 1/10)\n",
       "Delay: 5s, Duration: 00:00:00, Status: accepted\n",
       "Final job status: [succeeded]\n"
      ]
@@ -1226,14 +1175,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1241,75 +1189,54 @@
      "output_type": "stream",
      "text": [
       "Obtaining job logs from execution...\n",
-      "Job logs retrieved from [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump/jobs/6e23a817-e202-497e-841b-f1d5b2d6eb42/logs]:\n",
+      "Job logs retrieved from [https://pavics.ouranos.ca/weaver/providers/hummingbird/processes/ncdump/jobs/91b62b44-fb06-4be9-ad2b-43d5265d0048/logs]:\n",
       "\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   0% accepted   Job task submitted for execution.\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   0% running    Job started.\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   0% running    Job task setup initiated.\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   1% running    Job task setup completed.\n",
-      "[2022-08-24 15:25:05] DEBUG    [weaver.datatype.Job] 00:00:00   2% running    Employed WPS URL: [https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird]\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   2% running    Execute WPS request for process [ncdump]\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   3% running    Fetching job input definitions.\n",
-      "[2022-08-24 15:25:05] INFO     [weaver.datatype.Job] 00:00:00   4% running    Fetching job output definitions.\n",
-      "[2022-08-24 15:25:06] INFO     [weaver.datatype.Job] 00:00:00   5% running    Starting job process execution.\n",
-      "[2022-08-24 15:25:06] INFO     [weaver.datatype.Job] 00:00:00   5% running    Following updates could take a while until the Application Package answers...\n",
-      "[2022-08-24 15:25:09] DEBUG    [weaver.datatype.Job] 00:00:03   6% running    Updated job status location: [/data/wps_outputs/weaver/6e23a817-e202-497e-841b-f1d5b2d6eb42.xml].\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03   7% running    Starting monitoring of job execution.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03   8% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   1% running    Preparing package logs done.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03   9% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   2% running    Launching package...\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  11% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump] Visible application CWL euid:egid [1000:1000]\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  13% running    [2022-08-24 19:25:06] DEBUG    [weaver.processes.wps_package|ncdump] Using cwltool.RuntimeContext args:\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  14% running    {\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  16% running      \"no_read_only\": false,\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  18% running      \"no_match_user\": false,\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  19% running      \"tmpdir_prefix\": \"/tmp/wps_workdir/weaver/cwltool_tmp_\",\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  21% running      \"tmp_outdir_prefix\": \"/tmp/wps_workdir/weaver/cwltool_out_\",\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  23% running      \"outdir\": \"/tmp/wps_workdir/weaver/pywps_process_xnuwfx_d\",\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  24% running      \"debug\": true,\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  26% running      \"user_space_docker_cmd\": null,\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  28% running      \"strict_memory_limit\": false\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  30% running    }\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  31% running    [2022-08-24 19:25:06] INFO     [cwltool] Resolved '/tmp/tmpo7ereawa/ncdump' to 'file:///tmp/tmpo7ereawa/ncdump'\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  33% running    [2022-08-24 19:25:06] INFO     [cwltool] ../../../../tmp/tmpo7ereawa/ncdump:1:1: Unknown hint file:///tmp/tmpo7ereawa/WPS1Requirement\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  35% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   5% running    Loading package content done.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  36% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   6% running    Retrieve package inputs done.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  38% running    [2022-08-24 19:25:06] DEBUG    [weaver.processes.wps_package|ncdump] File input (dataset) DROPPED. Detected default format as data.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  40% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   8% running    Convert package inputs done.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  41% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   9% running    Checking package prerequisites... (operation could take a while depending on requirements)\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  43% running    [2022-08-24 19:25:06] DEBUG    [weaver.processes.wps_package|ncdump] Skipping Docker setup not needed for remote execution.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  45% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]   9% running    Package ready for execution.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  46% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]  10% running    Running package...\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  48% running    [2022-08-24 19:25:06] DEBUG    [weaver.processes.wps_package|ncdump] Launching process package with inputs:\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  50% running    {\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  52% running      \"dataset_opendap\": \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/birdhouse/testdata/ta_Amon_MRI-CGCM3_decadal1980_r1i1p1_199101-200012.nc\"\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  53% running    }\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  55% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]  10% running    Preparing to launch package ncdump.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  57% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump] WPS-1 Package resolved from requirement/hint: WPS1Requirement\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  58% running    [2022-08-24 19:25:06] INFO     [weaver.processes.wps_package|ncdump]  11% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Preparing process for remote execution.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  60% running    [2022-08-24 19:25:07] INFO     [weaver.processes.wps_package|ncdump]  14% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Process ready for execute remote process.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  62% running    [2022-08-24 19:25:07] INFO     [weaver.processes.wps_package|ncdump]  18% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Staging inputs for remote execution.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  63% running    [2022-08-24 19:25:07] INFO     [weaver.processes.wps_package|ncdump]  20% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Preparing inputs/outputs for remote execution.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  65% running    [2022-08-24 19:25:07] INFO     [weaver.processes.wps_package|ncdump]  22% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Executing remote process job.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  67% running    [2022-08-24 19:25:08] INFO     [weaver.processes.wps_package|ncdump]  27% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Monitoring remote process job until completion.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  68% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  82% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - 100% succeeded  PyWPS Process NCDump finished\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  70% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  82% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Retrieving job results definitions.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  72% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  82% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Retrieving job output definitions from remote WPS-1 provider.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  74% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  86% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Staging job outputs from remote process.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  75% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  90% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Running final cleanup operations before completion.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  77% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  95% succeeded  [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Execution of remote process execution completed successfully.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  79% running    [2022-08-24 19:25:09] DEBUG    [cwltool] Moving /tmp/wps_workdir/weaver/cwltool_out_erxzjwdu/nc_dump_cieH1d.txt to /tmp/wps_workdir/weaver/pywps_process_xnuwfx_d/nc_dump_cieH1d.txt\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  80% running    [2022-08-24 19:25:09] DEBUG    [cwltool] Moving /tmp/wps_workdir/weaver/cwltool_out_erxzjwdu/stderr.log to /tmp/wps_workdir/weaver/pywps_process_xnuwfx_d/stderr.log\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  82% running    [2022-08-24 19:25:09] DEBUG    [cwltool] Moving /tmp/wps_workdir/weaver/cwltool_out_erxzjwdu/stdout.log to /tmp/wps_workdir/weaver/pywps_process_xnuwfx_d/stdout.log\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  84% running    [2022-08-24 19:25:09] DEBUG    [cwltool] Removing intermediate output directory /tmp/wps_workdir/weaver/cwltool_out_erxzjwdu\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  85% running    [2022-08-24 19:25:09] DEBUG    [cwltool] Removing intermediate output directory /tmp/wps_workdir/weaver/cwltool_out_dr_ff_5_\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  87% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  95% running    Package execution done.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  89% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  95% running    Nothing captured from internal application logs.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  90% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump] Resolved WPS output [output] as file reference: [/tmp/wps_workdir/weaver/pywps_process_xnuwfx_d/nc_dump_cieH1d.txt]\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  92% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump]  98% running    Generate package outputs done.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  94% running    [2022-08-24 19:25:09] INFO     [weaver.processes.wps_package|ncdump] 100% succeeded  Package complete.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  96% succeeded  Job succeeded (status: Package complete.).\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03  98% succeeded  Job succeeded.\n",
-      "[2022-08-24 15:25:09] INFO     [weaver.datatype.Job] 00:00:03 100% succeeded  Job task complete.\n"
+      "[2023-09-01 16:39:07] INFO     [weaver.datatype.Job] 00:00:00   0% accepted   Job task submitted for execution.\n",
+      "[2023-09-01 16:39:07] INFO     [weaver.datatype.Job] 00:00:00   0% running    Job started.\n",
+      "[2023-09-01 16:39:07] INFO     [weaver.datatype.Job] 00:00:00   0% running    Job task setup initiated.\n",
+      "[2023-09-01 16:39:07] INFO     [weaver.datatype.Job] 00:00:00   1% running    Job task setup completed.\n",
+      "[2023-09-01 16:39:07] DEBUG    [weaver.datatype.Job] 00:00:00   2% running    Employed WPS URL: [https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird]\n",
+      "[2023-09-01 16:39:07] INFO     [weaver.datatype.Job] 00:00:00   2% running    Execute WPS request for process [ncdump]\n",
+      "[2023-09-01 16:39:08] INFO     [weaver.datatype.Job] 00:00:00   3% running    Fetching job input definitions.\n",
+      "[2023-09-01 16:39:08] INFO     [weaver.datatype.Job] 00:00:00   4% running    Fetching job output definitions.\n",
+      "[2023-09-01 16:39:08] INFO     [weaver.datatype.Job] 00:00:00   5% running    Starting job process execution.\n",
+      "[2023-09-01 16:39:08] INFO     [weaver.datatype.Job] 00:00:00   5% running    Following updates could take a while until the Application Package answers...\n",
+      "[2023-09-01 16:39:12] DEBUG    [weaver.datatype.Job] 00:00:04   6% running    Updated job status location: [/data/wps_outputs/weaver/91b62b44-fb06-4be9-ad2b-43d5265d0048.xml].\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04   7% running    Starting monitoring of job execution.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04   8% running    [2023-09-01 16:39:08] INFO     [weaver.processes.wps_package|ncdump]   1% running    Preparing package logs done.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  10% running    [2023-09-01 16:39:08] INFO     [weaver.processes.wps_package|ncdump]   2% running    Launching package...\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  13% running    [2023-09-01 16:39:08] WARNING  [weaver.processes.wps_package|ncdump] Visible application CWL euid:egid [0:0]\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  16% running    [2023-09-01 16:39:08] INFO     [cwltool] Resolved '/tmp/tmpw4u4bc2w/ncdump' to 'file:///tmp/tmpw4u4bc2w/ncdump'\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  19% running    [2023-09-01 16:39:09] INFO     [cwltool] ../../../../tmp/tmpw4u4bc2w/ncdump:1:1: Unknown hint file:///tmp/tmpw4u4bc2w/WPS1Requirement\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  22% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]   5% running    Loading package content done.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  25% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]   6% running    Retrieve package inputs done.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  27% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]   8% running    Convert package inputs done.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  30% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]   9% running    Checking package prerequisites... (operation could take a while depending on requirements)\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  33% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]   9% running    Package ready for execution.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  36% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  10% running    Running package...\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  39% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  10% running    Preparing to launch package ncdump.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  42% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump] WPS-1 Package resolved from requirement/hint: WPS1Requirement\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  44% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  11% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Preparing process for remote execution.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  47% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  14% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Process ready for execute remote process.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  50% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  18% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Staging inputs for remote execution.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  53% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  20% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Preparing inputs/outputs for remote execution.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  56% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  22% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Executing remote process job.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  59% running    [2023-09-01 16:39:09] INFO     [weaver.processes.wps_package|ncdump]  27% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Monitoring remote process job until completion.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  61% running    [2023-09-01 16:39:11] INFO     [weaver.processes.wps_package|ncdump]  27% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - 0% accepted   PyWPS Process ncdump accepted\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  64% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  82% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - 100% succeeded  PyWPS Process NCDump finished\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  67% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  82% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Retrieving job results definitions.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  70% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  82% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Retrieving job output definitions from remote WPS-1 provider.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  73% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  86% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Staging job outputs from remote process.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  76% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  90% running    [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Running final cleanup operations before completion.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  78% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  95% succeeded  [provider: https://pavics.ouranos.ca/twitcher/ows/proxy/hummingbird, step: ncdump] - Execution of remote process execution completed successfully.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  81% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  95% running    Package execution done.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  84% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  95% running    Nothing captured from internal application logs.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  87% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump] Resolved WPS output [output] as file reference: [/tmp/wps_workdir/weaver/pywps_process__ezcfmkz/nc_dump_2QIB8z.txt]\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  90% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump]  98% running    Generate package outputs done.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  93% running    [2023-09-01 16:39:12] INFO     [weaver.processes.wps_package|ncdump] 100% succeeded  Package complete.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  96% succeeded  Job succeeded (status: Package complete.).\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04  98% succeeded  Job succeeded.\n",
+      "[2023-09-01 16:39:12] INFO     [weaver.datatype.Job] 00:00:04 100% succeeded  Job task complete.\n"
      ]
     }
    ],
@@ -1349,14 +1276,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "metadata": {
-    "jupyter": {
-     "outputs_hidden": false
-    },
+    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1365,7 +1291,7 @@
      "text": [
       "\n",
       "Job was successful! Retrieving result location...\n",
-      "Result is located at: [https://pavics.ouranos.ca/wpsoutputs/weaver/public/54ce8f3f-8fe4-4081-8063-24fb8ea52250/nc_dump_6zwZ5z.txt]\n",
+      "Result is located at: [https://pavics.ouranos.ca/wpsoutputs/weaver/public/91b62b44-fb06-4be9-ad2b-43d5265d0048/nc_dump_2QIB8z.txt]\n",
       "\n",
       "Fetching output contents...\n",
       "\n",


### PR DESCRIPTION
Ran the weaver notebook against an instance deployed with https://github.com/bird-house/birdhouse-deploy/pull/376 to obtain the response outputs without `flyingpigeon` processes, and replaced back the `PAVICS_FQDN` value by the original one in the notebook.

- relates to https://github.com/Ouranosinc/pavics-sdi/pull/303
- relates to https://github.com/bird-house/birdhouse-deploy/pull/376
