### PR TITLE
output response body in assert message for debug during E2E tests

### DIFF
--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -190,7 +190,7 @@
     "\n",
     "assert \"providers\" in body and len(\n",
     "    body[\"providers\"]\n",
-    "), \"Could not find Weaver WPS providers\"\n",
+    "), f\"Could not find Weaver WPS providers in response:\\n{json_dump(body)}\"\n",
     "missing = []\n",
     "for bird in sorted(WEAVER_TEST_KNOWN_BIRDS):\n",
     "    if bird not in body[\"providers\"]:\n",


### PR DESCRIPTION
When running automated CI tests with E2E workflow, the JSON contents are not available directly. 
Add them to the assert error message to help debugging the cause.