### PR TITLE
fix kernelspec metadata for climex.ipynb

### DIFF
--- a/docs/source/notebooks/climex.ipynb
+++ b/docs/source/notebooks/climex.ipynb
@@ -4100,7 +4100,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "language": "python"
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
nbformat version 4.4 requires both `name` and `display_name` fields for the `kernelspec` key (https://github.com/jupyter/nbformat/blob/main/nbformat/v4/nbformat.v4.4.schema.json#L16).

This PR adds those to the climex.ipynb file where they appear to be missing so that tools, such as nbconvert, don't fail unexpectedly when trying to parse the metadata of this notebook.