### PR TITLE
eccc-geoapi-xclim.ipynb: ignore output because it varies too much

### DIFF
--- a/docs/source/notebooks/eccc-geoapi-xclim.ipynb
+++ b/docs/source/notebooks/eccc-geoapi-xclim.ipynb
@@ -243,6 +243,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "import os\n",
     "\n",
     "os.environ[\"USE_PYGEOS\"] = \"0\"  # force use Shapely with GeoPandas\n",
@@ -893,6 +895,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# Conver the GeoDataFrame to an xarray.Dataset\n",
     "# Different stations are aligned along the `station` dimension\n",
     "ds = preprocessing(gdf)\n",


### PR DESCRIPTION
Fails Jenkins again, even after previous fix
https://github.com/Ouranosinc/pavics-sdi/pull/312 that was tested to work.