### PR TITLE
update expected nested output id location for weaver wps outputs

### DIFF
--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -1282,7 +1282,7 @@
      "text": [
       "\n",
       "Job was successful! Retrieving result location...\n",
-      "Result is located at: [https://pavics.ouranos.ca/wpsoutputs/weaver/public/91b62b44-fb06-4be9-ad2b-43d5265d0048/nc_dump_2QIB8z.txt]\n",
+      "Result is located at: [https://pavics.ouranos.ca/wpsoutputs/weaver/public/91b62b44-fb06-4be9-ad2b-43d5265d0048/output/nc_dump_2QIB8z.txt]\n",
       "\n",
       "Fetching output contents...\n",
       "\n",


### PR DESCRIPTION
Add the missing `/output` in the URL of the produced WPS output of Weaver.