### PR TITLE
subset-user-input.ipynb: fix output for Thredds v5

### DIFF
--- a/docs/source/notebook-components/weaver_example.ipynb
+++ b/docs/source/notebook-components/weaver_example.ipynb
@@ -1380,7 +1380,7 @@
     "\n",
     "print(\"Fetching output contents...\")\n",
     "resp = requests.get(href)\n",
-    "print(f\"\\nNCDUMP 'output' result content:\\n\\n{resp.text}\")\n"
+    "print(f\"\\nNCDUMP 'output' result content:\\n\\n{resp.text}\")"
    ]
   }
  ],

--- a/docs/source/notebooks/subsetting.ipynb
+++ b/docs/source/notebooks/subsetting.ipynb
@@ -620,7 +620,7 @@
     "res = resp.get()\n",
     "print(\"URL: \", res.output)\n",
     "res = resp.get(asobj=True)\n",
-    "res.output\n"
+    "res.output"
    ]
   },
   {


### PR DESCRIPTION
Only merge if https://github.com/bird-house/birdhouse-deploy/pull/413 can be merged.

This is mostly to have a nice notebook diff.

```
15:47:13  ___ pavics-sdi-master/docs/source/notebooks/subset-user-input.ipynb::Cell 12 ___
15:47:13  Notebook cell execution failed
15:47:13  Cell 12: Cell outputs differ
15:47:13  
15:47:13  Input:
15:47:13  # gather data from the PAVICS data catalogue
15:47:13  catalog = "https://boreas.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml"  # TEST_USE_PROD_DATA
15:47:13  
15:47:13  cat = TDSCatalog(catalog)
15:47:13  data = cat.datasets[0].access_urls["OPENDAP"]
15:47:13  data
15:47:13  
15:47:13  Traceback:
15:47:13   mismatch 'text/plain'
15:47:13  
15:47:13   assert reference_output == test_output failed:
15:47:13  
15:47:13    "'https://pav...rcan_v2.ncml/'" == "'https://pav...s/nrcan.ncml'"
15:47:13    Skipping 70 identical leading characters in diff, use -v to show
15:47:13    - _obs/nrcan.ncml'
15:47:13    + _obs/nrcan_v2.ncml'
15:47:13    ?           +++
15:47:13
```