### PR TITLE
subset-user-input.ipynb: avoid dataset ordering change between Thredds v4 and v5

### DIFF
--- a/docs/source/notebooks/subset-user-input.ipynb
+++ b/docs/source/notebooks/subset-user-input.ipynb
@@ -490,7 +490,9 @@
     "catalog = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml\"  # TEST_USE_PROD_DATA\n",
     "\n",
     "cat = TDSCatalog(catalog)\n",
-    "data = cat.datasets[0].access_urls[\"OPENDAP\"]\n",
+    "data = [\n",
+    "    cat.datasets[d].access_urls[\"OPENDAP\"] for d in cat.datasets if \"nrcan_v2\" in d\n",
+    "][0]\n",
     "data"
    ]
   },
@@ -2397,7 +2399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Original commit was from Travis
https://github.com/Ouranosinc/pavics-sdi/pull/317/commits/0a76235d5bbef8e57ce061e50b47367d0a088f67

Replaces PR https://github.com/Ouranosinc/pavics-sdi/pull/317

To avoid this error when we will upgrade to Thredds v5, while being backward compatible with current Thredds v4:

```
15:47:13  ___ pavics-sdi-master/docs/source/notebooks/subset-user-input.ipynb::Cell 12 ___
15:47:13  Notebook cell execution failed
15:47:13  Cell 12: Cell outputs differ
15:47:13  
15:47:13  Input:
15:47:13  # gather data from the PAVICS data catalogue
15:47:13  catalog = "https://boreas.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml"  # TEST_USE_PROD_DATA
15:47:13  
15:47:13  cat = TDSCatalog(catalog)
15:47:13  data = cat.datasets[0].access_urls["OPENDAP"]
15:47:13  data
15:47:13  
15:47:13  Traceback:
15:47:13   mismatch 'text/plain'
15:47:13  
15:47:13   assert reference_output == test_output failed:
15:47:13  
15:47:13    "'https://pav...rcan_v2.ncml/'" == "'https://pav...s/nrcan.ncml'"
15:47:13    Skipping 70 identical leading characters in diff, use -v to show
15:47:13    - _obs/nrcan.ncml'
15:47:13    + _obs/nrcan_v2.ncml'
15:47:13    ?           +++
15:47:13
```