### PR TITLE
FAQ nb: ignore output when not related to data display to avoid breaking Jenkins

### DIFF
--- a/docs/source/notebooks/FAQ_dask_parallel.ipynb
+++ b/docs/source/notebooks/FAQ_dask_parallel.ipynb
@@ -75,6 +75,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# open dataset with unaligned chunks\n",
     "ds = xr.open_dataset(url, chunks={\"time\": 10, \"lat\": -1, \"lon\": -1})\n",
     "\n",
@@ -110,6 +112,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "# open dataset with aligned chunks\n",
     "ds = xr.open_dataset(url, chunks={\"time\": 366, \"lat\": 50 * 5, \"lon\": 50 * 5})\n",
     "\n",
@@ -526,6 +530,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "import time\n",
     "from pathlib import Path\n",
     "\n",
@@ -969,6 +975,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "import time\n",
     "from pathlib import Path\n",
     "\n",
@@ -1416,6 +1424,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "import time\n",
     "from pathlib import Path\n",
     "\n",
@@ -1628,6 +1638,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "import shutil\n",
     "import time\n",
     "from pathlib import Path\n",
@@ -1874,6 +1886,8 @@
     }
    ],
    "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "import shutil\n",
     "import time\n",
     "from pathlib import Path\n",
@@ -1977,7 +1991,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "my_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1991,7 +2005,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We still want to "not ignore output" when displaying data to confirm correctness and detect unintentional data change on the server, ex cell 1.

@aslibese FYI pavics-sdi notebooks are being tested nightly by Jenkins (http://jenkins.ouranos.ca/job/PAVICS-e2e-workflow-tests/job/master/) because they are automatically deployed to PAVICS as tutorial notebooks (https://pavics.ouranos.ca/jupyter/hub/user-redirect/lab/tree/tutorial-notebooks/FAQ_dask_parallel.ipynb) and we want to ensure our tutorial notebooks to always work for our end users.

Jenkins uses exactly the same Jupyter env deployed on PAVICS to run all the tutorial notebooks to ensure the runtime environment matches the notebooks.  It checks for no error and same output then the notebooks are run.  Therefore, for outputs that we don't care, we can ignore them.