### PR TITLE
Suppress epub.unknown_project_files warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -188,6 +188,7 @@ pygments_style = "sphinx"
 
 suppress_warnings = [
     "app.add_directive",
+    "epub.unknown_project_files",
     "mystnb.unknown_mime_type",
 ]
 


### PR DESCRIPTION
### Changes

* Adds a `suppress_warnings` entry for the very specific case where the `epub`-building step sees a `.favicon` and has no idea what to do with it.