### PR TITLE
Fix nb for jenkins

### DIFF
--- a/docs/source/notebooks/regridding.ipynb
+++ b/docs/source/notebooks/regridding.ipynb
@@ -1046,7 +1046,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "\n",
-    "url_obs = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml\"\n",
+    "url_obs = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/NRCAN/nrcan_v2.ncml\"\n",
     "\n",
     "# For this example, we're not interested in the observation data, only its underlying grid, so we'll select a single time step.\n",
     "ds_obs = xr.open_dataset(url_obs).sel(time=\"1993-05-20\").drop(\"time\")\n",
@@ -3890,7 +3890,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/subset-user-input.ipynb
+++ b/docs/source/notebooks/subset-user-input.ipynb
@@ -477,7 +477,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml'"
+       "'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/NRCAN/nrcan_v2.ncml'"
       ]
      },
      "execution_count": 13,
@@ -487,7 +487,7 @@
    ],
    "source": [
     "# gather data from the PAVICS data catalogue\n",
-    "catalog = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml\"  # TEST_USE_PROD_DATA\n",
+    "catalog = \"https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/NRCAN/catalog.xml\"  # TEST_USE_PROD_DATA\n",
     "\n",
     "cat = TDSCatalog(catalog)\n",
     "data = [\n",
@@ -2464,7 +2464,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pavics-sdi",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Fix this error:

```
  _______ pavics-sdi-master/docs/source/notebooks/regridding.ipynb::Cell 3 _______
  Notebook cell execution failed
  Cell 3: Cell execution caused an exception

  Input:
  # NBVAL_IGNORE_OUTPUT

  url_obs = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml"

  # For this example, we're not interested in the observation data, only its underlying grid, so we'll select a single time step.
  ds_obs = xr.open_dataset(url_obs).sel(time="1993-05-20").drop("time")

  # Subset over the Hudson Bay and the Labrador Sea for the example
  bbox = dict(lon_bnds=[-99.5, -41.92], lat_bnds=[50.35, 67.61])
  ds_tgt = subset_bbox(ds_obs, **bbox)
  ds_tgt

  Traceback:

  ---------------------------------------------------------------------------
  KeyError                                  Traceback (most recent call last)
  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/file_manager.py:219, in CachingFileManager._acquire_with_cache_info(self, needs_lock)
      218 try:
  --> 219     file = self._cache[self._key]
      220 except KeyError:

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/lru_cache.py:56, in LRUCache.__getitem__(self, key)
       55 with self._lock:
  ---> 56     value = self._cache[key]
       57     self._cache.move_to_end(key)

  KeyError: [<class 'netCDF4._netCDF4.Dataset'>, ('https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml',), 'r', (('clobber', True), ('diskless', False), ('format', 'NETCDF4'), ('persist', False)), 'db743fbe-5996-4f01-b0db-15bd7befc5ae']

  During handling of the above exception, another exception occurred:

  OSError                                   Traceback (most recent call last)
  Cell In[1], line 6
        2
        3 url_obs = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml"
        4
        5 # For this example, we're not interested in the observation data, only its underlying grid, so we'll select a single time step.
  ----> 6 ds_obs = xr.open_dataset(url_obs).sel(time="1993-05-20").drop("time")
        7
        8 # Subset over the Hudson Bay and the Labrador Sea for the example
        9 bbox = dict(lon_bnds=[-99.5, -41.92], lat_bnds=[50.35, 67.61])

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/api.py:596, in open_dataset(filename_or_obj, engine, chunks, cache, decode_cf, mask_and_scale, decode_times, decode_timedelta, use_cftime, concat_characters, decode_coords, drop_variables, create_default_indexes, inline_array, chunked_array_type, from_array_kwargs, backend_kwargs, **kwargs)
      584 decoders = _resolve_decoders_kwargs(
      585     decode_cf,
      586     open_backend_dataset_parameters=backend.open_dataset_parameters,
     (...)    592     decode_coords=decode_coords,
      593 )
      595 overwrite_encoded_chunks = kwargs.pop("overwrite_encoded_chunks", None)
  --> 596 backend_ds = backend.open_dataset(
      597     filename_or_obj,
      598     drop_variables=drop_variables,
      599     **decoders,
      600     **kwargs,
      601 )
      602 ds = _dataset_from_backend_dataset(
      603     backend_ds,
      604     filename_or_obj,
     (...)    615     **kwargs,
      616 )
      617 return ds

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/netCDF4_.py:744, in NetCDF4BackendEntrypoint.open_dataset(self, filename_or_obj, mask_and_scale, decode_times, concat_characters, decode_coords, drop_variables, use_cftime, decode_timedelta, group, mode, format, clobber, diskless, persist, auto_complex, lock, autoclose)
      722 def open_dataset(
      723     self,
      724     filename_or_obj: T_PathFileOrDataStore,
     (...)    741     autoclose=False,
      742 ) -> Dataset:
      743     filename_or_obj = _normalize_path(filename_or_obj)
  --> 744     store = NetCDF4DataStore.open(
      745         filename_or_obj,
      746         mode=mode,
      747         format=format,
      748         group=group,
      749         clobber=clobber,
      750         diskless=diskless,
      751         persist=persist,
      752         auto_complex=auto_complex,
      753         lock=lock,
      754         autoclose=autoclose,
      755     )
      757     store_entrypoint = StoreBackendEntrypoint()
      758     with close_on_error(store):

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/netCDF4_.py:524, in NetCDF4DataStore.open(cls, filename, mode, format, group, clobber, diskless, persist, auto_complex, lock, lock_maker, autoclose)
      520 else:
      521     manager = CachingFileManager(
      522         netCDF4.Dataset, filename, mode=mode, kwargs=kwargs
      523     )
  --> 524 return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/netCDF4_.py:428, in NetCDF4DataStore.__init__(self, manager, group, mode, lock, autoclose)
      426 self._group = group
      427 self._mode = mode
  --> 428 self.format = self.ds.data_model
      429 self._filename = self.ds.filepath()
      430 self.is_remote = is_remote_uri(self._filename)

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/netCDF4_.py:533, in NetCDF4DataStore.ds(self)
      531 https://github.com/Property
      532 def ds(self):
  --> 533     return self._acquire()

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/netCDF4_.py:527, in NetCDF4DataStore._acquire(self, needs_lock)
      526 def _acquire(self, needs_lock=True):
  --> 527     with self._manager.acquire_context(needs_lock) as root:
      528         ds = _nc4_require_group(root, self._group, self._mode)
      529     return ds

  File /opt/conda/envs/birdy/lib/python3.12/contextlib.py:137, in _GeneratorContextManager.__enter__(self)
      135 del self.args, self.kwds, self.func
      136 try:
  --> 137     return next(self.gen)
      138 except StopIteration:
      139     raise RuntimeError("generator didn't yield") from None

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/file_manager.py:207, in CachingFileManager.acquire_context(self, needs_lock)
      204 https://github.com/contextmanager
      205 def acquire_context(self, needs_lock: bool = True) -> Iterator[T_File]:
      206     """Context manager for acquiring a file."""
  --> 207     file, cached = self._acquire_with_cache_info(needs_lock)
      208     try:
      209         yield file

  File /opt/conda/envs/birdy/lib/python3.12/site-packages/xarray/backends/file_manager.py:225, in CachingFileManager._acquire_with_cache_info(self, needs_lock)
      223     kwargs = kwargs.copy()
      224     kwargs["mode"] = self._mode
  --> 225 file = self._opener(*self._args, **kwargs)
      226 if self._mode == "w":
      227     # ensure file doesn't get overridden when opened again
      228     self._mode = "a"

  File src/netCDF4/_netCDF4.pyx:2521, in netCDF4._netCDF4.Dataset.__init__()
  -> 2521 'Could not get source, probably due dynamically evaluated source code.'

  File src/netCDF4/_netCDF4.pyx:2158, in netCDF4._netCDF4._ensure_nc_success()
  -> 2158 'Could not get source, probably due dynamically evaluated source code.'

  OSError: [Errno -90] NetCDF: file not found: 'https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/dodsC/datasets/gridded_obs/nrcan_v2.ncml'
```
and this
```
  ___ pavics-sdi-master/docs/source/notebooks/subset-user-input.ipynb::Cell 12 ___
  Notebook cell execution failed
  Cell 12: Cell execution caused an exception

  Input:
  # gather data from the PAVICS data catalogue
  catalog = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml"  # TEST_USE_PROD_DATA

  cat = TDSCatalog(catalog)
  data = [
      cat.datasets[d].access_urls["OPENDAP"] for d in cat.datasets if "nrcan_v2" in d
  ][0]
  data

  Traceback:

  ---------------------------------------------------------------------------
  IndexError                                Traceback (most recent call last)
  Cell In[1], line 5
        1 # gather data from the PAVICS data catalogue
        2 catalog = "https://pavics.ouranos.ca/twitcher/ows/proxy/thredds/catalog/datasets/gridded_obs/catalog.xml"  # TEST_USE_PROD_DATA
        3
        4 cat = TDSCatalog(catalog)
  ----> 5 data = [
        6     cat.datasets[d].access_urls["OPENDAP"] for d in cat.datasets if "nrcan_v2" in d
        7 ][0]
        8 data

  IndexError: list index out of range
```