### PR TITLE
prometheus_metrics.ipynb: adapt for change from increase1h to rate1h

### DIFF
--- a/docs/source/notebook-components/prometheus_metrics.ipynb
+++ b/docs/source/notebook-components/prometheus_metrics.ipynb
@@ -39,6 +39,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ca564c95-a8b6-438e-a57a-5e5a2e6f0be3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install requests_magpie prometheus_pandas prometheus_api_client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1",
    "metadata": {},
    "outputs": [],
@@ -404,7 +414,8 @@
     "metrics = [\n",
     "    \"instance:node_cpu_seconds:avg_rate1h_not_idle\",\n",
     "    \"instance:node_network_transmit_bytes:sum_rate1h\",\n",
-    "    \"jupyter:container_cpu_user_seconds:sum_increase1h\",\n",
+    "    # this recording rule changed to rate1h but do not work anymore\n",
+    "    # \"jupyter:container_cpu_user_seconds:sum_increase1h\",\n",
     "    \"instance:go_threads:avg1h\",\n",
     "]\n",
     "for i, m in enumerate(metrics):\n",
@@ -476,7 +487,7 @@
     "    d = int(_duration(end - start))\n",
     "\n",
     "    # Return download volumes larger than ~1GB by dataset during period (summing over variables, IP addresses, transfer protocol)\n",
-    "    expr = f\"sort_desc(sum by (dataset) (increase(instance:thredds_transfer_size_bytes:increase1h[{d}s]) > 10^9))\"\n",
+    "    expr = f\"sort_desc(sum by (dataset) (avg_over_time(instance:thredds_transfer_size_bytes:rate1h[{d}s]) * {d}) > 10^9)\"\n",
     "\n",
     "    df = prom.query(expr, time=end)[:n] / 1024**4\n",
     "\n",
@@ -659,7 +670,7 @@
     "    d = int(_duration(end - start))\n",
     "\n",
     "    # Return download volumes larger than ~1Mb by IP address during period\n",
-    "    expr = f\"sort_desc(sum by (remote_addr) (increase(instance:thredds_transfer_size_bytes:increase1h[{d}s]) > 10^6))\"\n",
+    "    expr = f\"sort_desc(sum by (remote_addr) (avg_over_time(instance:thredds_transfer_size_bytes:rate1h[{d}s]) * {d}) > 10^6)\"\n",
     "\n",
     "    df = prom.query(expr, time=end) / 1024**3\n",
     "    return to_dataarray(\n",
@@ -750,7 +761,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pavics-sdi",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -764,7 +775,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebook-components/prometheus_metrics.ipynb
+++ b/docs/source/notebook-components/prometheus_metrics.ipynb
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca564c95-a8b6-438e-a57a-5e5a2e6f0be3",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 133,
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": 134,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": 135,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Plotting metrics time series\n",
@@ -392,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [
     {
@@ -424,7 +424,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Analysing THREDDS downloads\n",
@@ -445,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [
     {
@@ -515,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
In prod, before June 19 it's the old `increase1h` rule and after it has been renamed to the new `rate1h` rule !  

If querying over that date, need to switch the query string accordingly !  This is the reason there was "no data" after June 19.  The data is still there but the query string needs to match the new rule.

The change in this notebook shows the matching new query string to achieve the same result.

This notebook now pass until the end.